### PR TITLE
fix: rendre les commerces de détail privés par chasseur

### DIFF
--- a/api-express/src/controllers/entite.ts
+++ b/api-express/src/controllers/entite.ts
@@ -177,7 +177,6 @@ router.get(
           deleted_at: null,
           type: {
             in: [
-              EntityTypes.COMMERCE_DE_DETAIL,
               EntityTypes.CANTINE_OU_RESTAURATION_COLLECTIVE,
               EntityTypes.ASSOCIATION_CARITATIVE,
               EntityTypes.REPAS_DE_CHASSE_OU_ASSOCIATIF,

--- a/api-express/src/controllers/user.ts
+++ b/api-express/src/controllers/user.ts
@@ -1381,6 +1381,7 @@ router.get(
                 EntityTypes.PREMIER_DETENTEUR, // les associations de chasse doivent rester confidentielles
                 EntityTypes.SVI, // les SVI sont déjà inclus dans les ETGs
                 EntityTypes.CONSOMMATEUR_FINAL, // les collecteurs pro sont déjà inclus dans les associations de chasse
+                EntityTypes.COMMERCE_DE_DETAIL, // les commerces de détail sont privés, visibles uniquement par le chasseur qui les a créés
               ],
             },
             id: {


### PR DESCRIPTION
Même logique que CONSOMMATEUR_FINAL : un commerce de détail créé par un chasseur n'est visible que sur son compte.