### PR TITLE
fix: paginate carcasses registry to fix 100-row cap

### DIFF
--- a/app-local-first-react-router/src/utils/load-carcasses.ts
+++ b/app-local-first-react-router/src/utils/load-carcasses.ts
@@ -5,13 +5,10 @@ import { mergeItems } from './merge-fetched-items';
 import API from '@app/services/api';
 
 const PAGE_SIZE = 1000;
-// Bump this constant to force a one-shot full re-sync on all existing clients
-// (e.g. after fixing a bug that left local stores incomplete).
-const CARCASSES_REGISTRY_SYNC_VERSION = 1;
 
 export async function loadCarcasses(role: UserRoles) {
-  const state = useZustandStore.getState();
-  if (!state.isOnline) {
+  const isOnline = useZustandStore.getState().isOnline;
+  if (!isOnline) {
     console.log('not loading fei because not online');
     return;
   }
@@ -20,9 +17,7 @@ export async function loadCarcasses(role: UserRoles) {
   // is picked up on the next delta sync.
   const serverDate = await API.get({ path: 'now' }).then((res) => (res.ok ? res.data : null));
 
-  const needsFullSync = state.carcassesRegistrySyncVersion < CARCASSES_REGISTRY_SYNC_VERSION;
-  const after = needsFullSync ? '0' : String(state.lastUpdateCarcassesRegistry);
-
+  const after = String(useZustandStore.getState().lastUpdateCarcassesRegistry);
   const fetched: CarcassesGetForRegistryResponse['data']['carcasses'] = [];
   let page = 0;
   let hasMore = true;
@@ -44,18 +39,15 @@ export async function loadCarcasses(role: UserRoles) {
     page += 1;
   }
 
-  const newRegistry = needsFullSync
-    ? fetched.filter((c) => !c.deleted_at)
-    : mergeItems({
-        oldItems: useZustandStore.getState().carcassesRegistry || [],
-        newItems: fetched,
-        idKey: 'zacharie_carcasse_id',
-      });
+  const newRegistry = mergeItems({
+    oldItems: useZustandStore.getState().carcassesRegistry || [],
+    newItems: fetched,
+    idKey: 'zacharie_carcasse_id',
+  });
 
   useZustandStore.setState(() => ({
     carcassesRegistry: newRegistry,
     lastUpdateCarcassesRegistry: serverDate,
-    carcassesRegistrySyncVersion: CARCASSES_REGISTRY_SYNC_VERSION,
   }));
 
   return fetched;

--- a/app-local-first-react-router/src/utils/load-carcasses.ts
+++ b/app-local-first-react-router/src/utils/load-carcasses.ts
@@ -4,38 +4,59 @@ import { UserRoles } from '@prisma/client';
 import { mergeItems } from './merge-fetched-items';
 import API from '@app/services/api';
 
+const PAGE_SIZE = 1000;
+// Bump this constant to force a one-shot full re-sync on all existing clients
+// (e.g. after fixing a bug that left local stores incomplete).
+const CARCASSES_REGISTRY_SYNC_VERSION = 1;
+
 export async function loadCarcasses(role: UserRoles) {
-  const isOnline = useZustandStore.getState().isOnline;
-  if (!isOnline) {
+  const state = useZustandStore.getState();
+  if (!state.isOnline) {
     console.log('not loading fei because not online');
     return;
   }
 
-  // Get date from server before downloading the data
-  // We'll set the `lastUpdateCarcassesRegistry` to this date after all the data is downloaded
+  // Read server time before pagination so any carcasse touched during the loop
+  // is picked up on the next delta sync.
   const serverDate = await API.get({ path: 'now' }).then((res) => (res.ok ? res.data : null));
 
-  const carcassesData = await API.get({
-    path: `carcasse/${role.toLocaleLowerCase()}`,
-    query: {
-      after: String(useZustandStore.getState().lastUpdateCarcassesRegistry),
-      withDeleted: 'true',
-    },
-  }).then((res) => res as CarcassesGetForRegistryResponse);
-  if (!carcassesData.ok) {
-    return null;
+  const needsFullSync = state.carcassesRegistrySyncVersion < CARCASSES_REGISTRY_SYNC_VERSION;
+  const after = needsFullSync ? '0' : String(state.lastUpdateCarcassesRegistry);
+
+  const fetched: CarcassesGetForRegistryResponse['data']['carcasses'] = [];
+  let page = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const res = await API.get({
+      path: `carcasse/${role.toLocaleLowerCase()}`,
+      query: {
+        after,
+        withDeleted: 'true',
+        page: String(page),
+        limit: String(PAGE_SIZE),
+      },
+    }).then((r) => r as CarcassesGetForRegistryResponse);
+    if (!res.ok) return null;
+
+    fetched.push(...(res.data.carcasses || []));
+    hasMore = res.data.hasMore;
+    page += 1;
   }
 
-  const newCarcassesRegistry = mergeItems({
-    oldItems: useZustandStore.getState().carcassesRegistry || [],
-    newItems: carcassesData.data.carcasses || [],
-    idKey: 'zacharie_carcasse_id',
-  });
+  const newRegistry = needsFullSync
+    ? fetched.filter((c) => !c.deleted_at)
+    : mergeItems({
+        oldItems: useZustandStore.getState().carcassesRegistry || [],
+        newItems: fetched,
+        idKey: 'zacharie_carcasse_id',
+      });
 
   useZustandStore.setState(() => ({
-    carcassesRegistry: newCarcassesRegistry,
+    carcassesRegistry: newRegistry,
     lastUpdateCarcassesRegistry: serverDate,
+    carcassesRegistrySyncVersion: CARCASSES_REGISTRY_SYNC_VERSION,
   }));
 
-  return carcassesData.data.carcasses;
+  return fetched;
 }

--- a/app-local-first-react-router/src/zustand/store.ts
+++ b/app-local-first-react-router/src/zustand/store.ts
@@ -41,7 +41,6 @@ const PERSISTED_KEYS: (keyof State)[] = [
   'carcassesIntermediaireById',
   'apiKeyApprovals',
   'lastUpdateCarcassesRegistry',
-  'carcassesRegistrySyncVersion',
   'carcassesRegistry',
   'logs',
 ];
@@ -58,7 +57,6 @@ export interface State {
   carcassesIntermediaireById: Record<FeiAndCarcasseAndIntermediaireIds, CarcasseIntermediaire>;
   apiKeyApprovals: NonNullable<UserConnexionResponse['data']['apiKeyApprovals']>;
   lastUpdateCarcassesRegistry: number;
-  carcassesRegistrySyncVersion: number;
   carcassesRegistry: Array<CarcasseForResponseForRegistry>;
   logs: Array<Log>;
   _hasHydrated: boolean;
@@ -135,7 +133,6 @@ const initialState: State = {
   dataIsSynced: true,
   carcassesRegistry: [],
   lastUpdateCarcassesRegistry: 0,
-  carcassesRegistrySyncVersion: 0,
   logs: [],
   feis: {},
   users: {},
@@ -423,13 +420,23 @@ const useZustandStore = create<State & Actions>()(
       }),
       {
         name: 'zacharie-zustand-store',
-        version: 5,
+        version: 6,
         storage: createSlicedIDBStorage<Partial<State>>(PERSISTED_KEYS),
         onRehydrateStorage: (state) => {
           return () => state.setHasHydrated(true);
         },
         partialize: (state) =>
           Object.fromEntries(PERSISTED_KEYS.map((key) => [key, state[key]])) as Partial<State>,
+        // v6: pagination fix for carcassesRegistry. Old clients had at most ~100
+        // rows persisted; reset the registry + delta-cursor so the next load
+        // refetches everything from scratch.
+        migrate: (persistedState, version) => {
+          const state = persistedState as Partial<State>;
+          if (version < 6) {
+            return { ...state, lastUpdateCarcassesRegistry: 0, carcassesRegistry: [] };
+          }
+          return state;
+        },
       }
     )
   )

--- a/app-local-first-react-router/src/zustand/store.ts
+++ b/app-local-first-react-router/src/zustand/store.ts
@@ -41,6 +41,7 @@ const PERSISTED_KEYS: (keyof State)[] = [
   'carcassesIntermediaireById',
   'apiKeyApprovals',
   'lastUpdateCarcassesRegistry',
+  'carcassesRegistrySyncVersion',
   'carcassesRegistry',
   'logs',
 ];
@@ -57,6 +58,7 @@ export interface State {
   carcassesIntermediaireById: Record<FeiAndCarcasseAndIntermediaireIds, CarcasseIntermediaire>;
   apiKeyApprovals: NonNullable<UserConnexionResponse['data']['apiKeyApprovals']>;
   lastUpdateCarcassesRegistry: number;
+  carcassesRegistrySyncVersion: number;
   carcassesRegistry: Array<CarcasseForResponseForRegistry>;
   logs: Array<Log>;
   _hasHydrated: boolean;
@@ -133,6 +135,7 @@ const initialState: State = {
   dataIsSynced: true,
   carcassesRegistry: [],
   lastUpdateCarcassesRegistry: 0,
+  carcassesRegistrySyncVersion: 0,
   logs: [],
   feis: {},
   users: {},


### PR DESCRIPTION
The /etg, /svi, /collecteur_pro endpoints default to limit=100. The frontend made a single non-paginated call, so registries with more than 100 carcasses were truncated and filters operated on an incomplete subset.

Loop pagination via hasMore. Existing accounts are migrated automatically via a sync-version flag: a one-shot full sync (after=0) backfills the missing rows, then subsequent loads resume normal delta-sync.