### PR TITLE
fix: onboarding etg/collecteur/svi/circuit-court

### DIFF
--- a/api-express/src/__tests__/user-onboarding-finished.test.ts
+++ b/api-express/src/__tests__/user-onboarding-finished.test.ts
@@ -1,0 +1,137 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import userRouter from '~/controllers/user';
+import { sendError } from '~/middlewares/errors';
+import prisma from '~/prisma';
+import { type User, UserRoles } from '@prisma/client';
+
+vi.mock('~/third-parties/brevo', () => ({
+  createBrevoContact: vi.fn().mockResolvedValue(undefined),
+  updateBrevoContact: vi.fn().mockResolvedValue(undefined),
+  updateBrevoChasseurDeal: vi.fn().mockResolvedValue(undefined),
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/third-parties/sentry', () => ({
+  capture: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock('~/utils/send-onboarding-email', () => ({
+  sendOnboardingEmailOnce: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/utils/invite-user', () => ({
+  inviteUser: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/utils/federation-stats', () => ({
+  ensureScopeForRoles: vi.fn((roles: UserRoles[]) => roles),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/user', userRouter);
+app.use(sendError);
+
+function authed(req: request.Test, user: object) {
+  return req.set('x-test-user', JSON.stringify(user));
+}
+
+// A non-CHASSEUR onboarding user (ETG / SVI / COLLECTEUR_PRO / circuit-court all share this code path:
+// the only step left to finish onboarding is POST /user/:id { onboarding_finished: true }).
+const baseUser = {
+  id: 'user-etg',
+  email: 'arnaud-etg-bouce@ambroselli.io',
+  roles: [UserRoles.ETG],
+  prenom: 'Bouce',
+  nom_de_famille: 'AMBRO',
+  telephone: '09234',
+  addresse_ligne_1: '12 de la Bouce',
+  code_postal: '56470',
+  ville: 'ST PHILIBERT',
+  onboarded_at: null as Date | null,
+};
+
+// Saved user returned by prisma.user.update — onboarded_at is now set, every required field present.
+const savedUser = {
+  ...baseUser,
+  onboarded_at: new Date('2026-06-17T07:15:30.000Z'),
+} as unknown as User;
+
+describe('POST /user/:id — onboarding_finished', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('unauthenticated → 401', async () => {
+    await request(app).post('/user/user-etg').send({ onboarding_finished: true }).expect(401);
+  });
+
+  test('cannot finish onboarding for another user → 403', async () => {
+    const res = await authed(
+      request(app).post('/user/someone-else').send({ onboarding_finished: true }),
+      baseUser
+    );
+    expect(res.status).toBe(403);
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  test('finishing onboarding sets onboarded_at and sends both emails', async () => {
+    // @ts-expect-error mocked module
+    const { sendOnboardingEmailOnce } = await import('~/utils/send-onboarding-email');
+    // @ts-expect-error mocked module
+    const { sendEmail } = await import('~/third-parties/brevo');
+
+    vi.mocked(prisma.user.update).mockResolvedValue(savedUser);
+
+    const res = await authed(
+      request(app).post('/user/user-etg').send({ onboarding_finished: true }),
+      baseUser
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    // onboarded_at is stamped at write time.
+    expect(prisma.user.update).toHaveBeenCalledOnce();
+    const updateData = vi.mocked(prisma.user.update).mock.calls[0][0].data as Record<string, unknown>;
+    expect(updateData.onboarded_at).toBeInstanceOf(Date);
+
+    // Internal notice "Inscription finie" to the Zacharie team.
+    expect(sendEmail).toHaveBeenCalledOnce();
+    const internalEmail = vi.mocked(sendEmail).mock.calls[0][0];
+    expect(internalEmail.emails).toEqual(['contact@zacharie.beta.gouv.fr']);
+    expect(internalEmail.subject).toMatch(/Inscription finie/i);
+    expect(internalEmail.text).toContain(baseUser.email);
+
+    // "Inscription en examen" mail to the user, deduplicated once per account.
+    expect(sendOnboardingEmailOnce).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendOnboardingEmailOnce).mock.calls[0][0]).toMatchObject({
+      user: savedUser,
+      action: 'INSCRIPTION_EN_EXAMEN',
+    });
+  });
+
+  test('re-finishing onboarding (already onboarded) does not resend onboarding emails', async () => {
+    // @ts-expect-error mocked module
+    const { sendOnboardingEmailOnce } = await import('~/utils/send-onboarding-email');
+    // @ts-expect-error mocked module
+    const { sendEmail } = await import('~/third-parties/brevo');
+
+    const alreadyOnboarded = { ...baseUser, onboarded_at: new Date('2026-01-01T00:00:00.000Z') };
+    vi.mocked(prisma.user.update).mockResolvedValue({ ...savedUser, ...alreadyOnboarded } as User);
+
+    const res = await authed(
+      request(app).post('/user/user-etg').send({ onboarding_finished: true }),
+      alreadyOnboarded
+    );
+
+    expect(res.status).toBe(200);
+    // The write still happens, but no onboarding email is (re)triggered.
+    expect(prisma.user.update).toHaveBeenCalledOnce();
+    expect(sendOnboardingEmailOnce).not.toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+});

--- a/app-local-first-react-router/src/routes/circuit-court/onboarding/2-entreprise.tsx
+++ b/app-local-first-react-router/src/routes/circuit-court/onboarding/2-entreprise.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { ButtonsGroup } from '@codegouvfr/react-dsfr/ButtonsGroup';
 import { Stepper } from '@codegouvfr/react-dsfr/Stepper';
 import { CallOut } from '@codegouvfr/react-dsfr/CallOut';
 import { EntityTypes, UserRoles } from '@prisma/client';
-import type { EntitiesWorkingForResponse } from '@api/src/types/responses';
+import type { EntitiesWorkingForResponse, UserConnexionResponse } from '@api/src/types/responses';
 import type { EntitiesByTypeAndId } from '@api/src/types/entity';
 import useUser from '@app/zustand/user';
 import { useNavigate } from 'react-router';
@@ -48,6 +48,17 @@ export default function CircuitCourtOnboardingEntreprise() {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
+
+  const handleUserOnboardingFinished = useCallback(async () => {
+    const response = await API.post({
+      path: `/user/${user.id}`,
+      body: { onboarding_finished: true },
+    }).then((data) => data as UserConnexionResponse);
+    if (response.ok && response.data?.user?.id) {
+      useUser.setState({ user: response.data.user });
+    }
+    navigate('/app/circuit-court');
+  }, [user.id, navigate]);
 
   return (
     <>
@@ -133,7 +144,7 @@ export default function CircuitCourtOnboardingEntreprise() {
                       type: 'button',
                       nativeButtonProps: {
                         onClick: () => {
-                          navigate('/app/circuit-court');
+                          handleUserOnboardingFinished();
                         },
                       },
                     },

--- a/app-local-first-react-router/src/routes/collecteur/onboarding/2-entreprise.tsx
+++ b/app-local-first-react-router/src/routes/collecteur/onboarding/2-entreprise.tsx
@@ -53,6 +53,17 @@ export default function CollecteurOnboardingEntreprise() {
     [user.id]
   );
 
+  const handleUserOnboardingFinished = useCallback(async () => {
+    const response = await API.post({
+      path: `/user/${user.id}`,
+      body: { onboarding_finished: true },
+    }).then((data) => data as UserConnexionResponse);
+    if (response.ok && response.data?.user?.id) {
+      useUser.setState({ user: response.data.user });
+    }
+    navigate('/app/collecteur');
+  }, [user.id, navigate]);
+
   return (
     <>
       <title>Entreprise | Zacharie | Ministère de l'Agriculture et de la Souveraineté Alimentaire</title>
@@ -127,7 +138,7 @@ export default function CollecteurOnboardingEntreprise() {
                       type: 'button',
                       nativeButtonProps: {
                         onClick: () => {
-                          navigate('/app/collecteur');
+                          handleUserOnboardingFinished();
                         },
                       },
                     },

--- a/app-local-first-react-router/src/routes/etg/onboarding/2-entreprise.tsx
+++ b/app-local-first-react-router/src/routes/etg/onboarding/2-entreprise.tsx
@@ -54,6 +54,17 @@ export default function EtgOnboardingEntreprise() {
     [user.id]
   );
 
+  const handleUserOnboardingFinished = useCallback(async () => {
+    const response = await API.post({
+      path: `/user/${user.id}`,
+      body: { onboarding_finished: true },
+    }).then((data) => data as UserConnexionResponse);
+    if (response.ok && response.data?.user?.id) {
+      useUser.setState({ user: response.data.user });
+    }
+    navigate('/app/etg');
+  }, [user.id, navigate]);
+
   return (
     <>
       <title>{`Entreprise | Zacharie | Ministère de l'Agriculture et de la Souveraineté Alimentaire`}</title>
@@ -177,7 +188,7 @@ export default function EtgOnboardingEntreprise() {
                       type: 'button',
                       nativeButtonProps: {
                         onClick: () => {
-                          navigate('/app/etg');
+                          handleUserOnboardingFinished();
                         },
                       },
                     },

--- a/app-local-first-react-router/src/routes/svi/onboarding/2-entreprise.tsx
+++ b/app-local-first-react-router/src/routes/svi/onboarding/2-entreprise.tsx
@@ -1,15 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router';
 import { EntityTypes } from '@prisma/client';
 import { ButtonsGroup } from '@codegouvfr/react-dsfr/ButtonsGroup';
 import { Stepper } from '@codegouvfr/react-dsfr/Stepper';
 import { CallOut } from '@codegouvfr/react-dsfr/CallOut';
-import type { EntitiesWorkingForResponse } from '@api/src/types/responses';
+import type { EntitiesWorkingForResponse, UserConnexionResponse } from '@api/src/types/responses';
 import type { EntitiesById } from '@api/src/types/entity';
 import API from '@app/services/api';
 import ListAndSelectEntities from '@app/components/ListAndSelectEntities';
+import useUser from '@app/zustand/user';
 
 export default function SviOnboardingEntreprise() {
+  const user = useUser((state) => state.user)!;
   const [allEntitiesById, setAllEntitiesById] = useState<EntitiesById>({});
   const [userEntitiesById, setUserEntitiesById] = useState<EntitiesById>({});
   const [refreshKey, setRefreshKey] = useState(0);
@@ -29,6 +31,17 @@ export default function SviOnboardingEntreprise() {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
+
+  const handleUserOnboardingFinished = useCallback(async () => {
+    const response = await API.post({
+      path: `/user/${user.id}`,
+      body: { onboarding_finished: true },
+    }).then((data) => data as UserConnexionResponse);
+    if (response.ok && response.data?.user?.id) {
+      useUser.setState({ user: response.data.user });
+    }
+    navigate('/app/svi');
+  }, [user.id, navigate]);
 
   return (
     <>
@@ -77,7 +90,7 @@ export default function SviOnboardingEntreprise() {
                       type: 'button',
                       nativeButtonProps: {
                         onClick: () => {
-                          navigate('/app/svi');
+                          handleUserOnboardingFinished();
                         },
                       },
                     },


### PR DESCRIPTION
  Previously the final onboarding step (2-entreprise) for collecteur/etg/svi just called
  navigate('/app/<role>') without ever marking onboarding finished. So onboarded_at was never
  stamped and the two inscription emails (the team notice + the "examiné sous 48h" mail to the user)
  never fired at the end of onboarding. Your PR fixes this by POSTing { onboarding_finished: true }
  first — which is exactly the dev-mode email output you pasted. The frontend pattern matches the
  existing chasseur reference (3-informations-de-chasse.tsx). ✅