### PR TITLE
feat: chasseur avec CFEI peut créer une fiche sans la transmettre

### DIFF
--- a/api-express/src/__tests__/permissions-carcasse-ownership.test.ts
+++ b/api-express/src/__tests__/permissions-carcasse-ownership.test.ts
@@ -142,8 +142,16 @@ describe('Role branching — where clause shape', () => {
     expect(where.OR).toEqual([
       { premier_detenteur_user_id: chasseurUser.id },
       { examinateur_initial_user_id: chasseurUser.id },
-      { premier_detenteur_entity_id: { in: ['entity-1', 'entity-2'] } },
-      { next_owner_entity_id: { in: ['entity-1', 'entity-2'] } },
+      // Désignation du premier détenteur (entité) : exposée aux membres de l'entité seulement
+      // une fois la fiche réellement transmise (sortie de l'examinateur initial).
+      {
+        premier_detenteur_entity_id: { in: ['entity-1', 'entity-2'] },
+        Fei: { fei_current_owner_role: { not: 'EXAMINATEUR_INITIAL' } },
+      },
+      {
+        next_owner_entity_id: { in: ['entity-1', 'entity-2'] },
+        Fei: { fei_current_owner_role: { not: 'EXAMINATEUR_INITIAL' } },
+      },
       { prev_owner_entity_id: { in: ['entity-1', 'entity-2'] } },
       { current_owner_entity_id: { in: ['entity-1', 'entity-2'] } },
       { next_owner_user_id: chasseurUser.id },

--- a/api-express/src/controllers/carcasse.ts
+++ b/api-express/src/controllers/carcasse.ts
@@ -7,6 +7,7 @@ import prisma from '~/prisma';
 import {
   EntityRelationStatus,
   EntityRelationType,
+  FeiOwnerRole,
   Prisma,
   TrichineResultatAnalyse,
   UserRoles,
@@ -96,11 +97,16 @@ router.get(
           {
             examinateur_initial_user_id: req.user.id,
           },
+          // Désignation du premier détenteur (asso) : on n'expose la fiche aux membres de
+          // l'entité qu'une fois la fiche réellement transmise (sortie de l'examinateur initial),
+          // pas dès la simple désignation en cours de préparation.
           {
             premier_detenteur_entity_id: { in: userEntityIds },
+            Fei: { fei_current_owner_role: { not: FeiOwnerRole.EXAMINATEUR_INITIAL } },
           },
           {
             next_owner_entity_id: { in: userEntityIds },
+            Fei: { fei_current_owner_role: { not: FeiOwnerRole.EXAMINATEUR_INITIAL } },
           },
           {
             prev_owner_entity_id: { in: userEntityIds },

--- a/api-express/src/controllers/carcasse.ts
+++ b/api-express/src/controllers/carcasse.ts
@@ -36,7 +36,10 @@ router.get(
   '/',
   passport.authenticate('user', { session: false }),
   catchErrors(async (req: RequestWithUser, res: express.Response<CarcassesGetResponse>) => {
-    if (!req.user.activated) {
+    // Un chasseur formé (numéro CFEI) non encore activé peut charger ses fiches en préparation.
+    const isExaminateurInitialNotYetActivated =
+      req.user.roles.includes(UserRoles.CHASSEUR) && !!req.user.numero_cfei;
+    if (!req.user.activated && !isExaminateurInitialNotYetActivated) {
       res.status(400).send({
         ok: false,
         data: null,

--- a/api-express/src/controllers/sync.ts
+++ b/api-express/src/controllers/sync.ts
@@ -3,7 +3,7 @@ import passport from 'passport';
 import { catchErrors } from '~/middlewares/errors';
 import type { SyncRequest, SyncResponse } from '~/types/responses';
 import prisma from '~/prisma';
-import { Carcasse, Prisma, User } from '@prisma/client';
+import { Prisma, User, UserRoles, Carcasse } from '@prisma/client';
 import { syncFei, type SaveFeiResult } from '~/utils/sync-fei';
 import { syncCarcasse, type SaveCarcasseResult } from '~/utils/sync-carcasse';
 import { syncCarcasseIntermediaire } from '~/utils/sync-carcasse-intermediaire';
@@ -30,7 +30,10 @@ router.post(
   catchErrors(async (req: express.Request, res: express.Response<SyncResponse>) => {
     const user = req.user as User;
 
-    if (!user.activated) {
+    // Un chasseur formé (numéro CFEI) non encore activé peut synchroniser ses fiches en
+    // préparation. La transmission reste bloquée plus bas (syncFei / syncCarcasse).
+    const isExaminateurInitialNotYetActivated = user.roles.includes(UserRoles.CHASSEUR) && !!user.numero_cfei;
+    if (!user.activated && !isExaminateurInitialNotYetActivated) {
       res.status(400).send({
         ok: false,
         data: null,

--- a/api-express/src/utils/sync-carcasse.ts
+++ b/api-express/src/utils/sync-carcasse.ts
@@ -1,5 +1,5 @@
 import prisma from '~/prisma';
-import { Carcasse, EntityRelationType, Prisma, User, UserRoles } from '@prisma/client';
+import { Carcasse, EntityRelationType, FeiOwnerRole, Prisma, User, UserRoles } from '@prisma/client';
 
 export interface SaveCarcasseResult {
   savedCarcasse: Carcasse;
@@ -25,12 +25,15 @@ export async function syncCarcasse(
   if (!zacharie_carcasse_id) {
     throw new Error('Le numéro de la carcasse est obligatoire');
   }
-  // Tant que le compte n'est pas activé (CFEI non validé), l'examinateur initial peut
-  // préparer ses carcasses mais pas les transmettre : on rejette l'assignation d'un prochain détenteur.
+  // Tant que le compte n'est pas activé (CFEI non validé), l'examinateur initial peut préparer
+  // sa fiche et désigner le premier détenteur (next_owner = PREMIER_DETENTEUR), mais pas la
+  // transmettre en aval : on rejette l'assignation d'un prochain détenteur au-delà du 1er détenteur.
   if (!user.activated) {
-    const assignsNextOwner =
-      !!body.next_owner_role || !!body.next_owner_user_id || !!body.next_owner_entity_id;
-    if (assignsNextOwner) {
+    const transmitsToNextDetenteur =
+      !!body.next_owner_role &&
+      body.next_owner_role !== FeiOwnerRole.PREMIER_DETENTEUR &&
+      body.next_owner_role !== FeiOwnerRole.EXAMINATEUR_INITIAL;
+    if (transmitsToNextDetenteur) {
       throw new Error('Votre compte doit être validé avant de pouvoir transmettre une fiche');
     }
   }

--- a/api-express/src/utils/sync-carcasse.ts
+++ b/api-express/src/utils/sync-carcasse.ts
@@ -25,6 +25,15 @@ export async function syncCarcasse(
   if (!zacharie_carcasse_id) {
     throw new Error('Le numéro de la carcasse est obligatoire');
   }
+  // Tant que le compte n'est pas activé (CFEI non validé), l'examinateur initial peut
+  // préparer ses carcasses mais pas les transmettre : on rejette l'assignation d'un prochain détenteur.
+  if (!user.activated) {
+    const assignsNextOwner =
+      !!body.next_owner_role || !!body.next_owner_user_id || !!body.next_owner_entity_id;
+    if (assignsNextOwner) {
+      throw new Error('Votre compte doit être validé avant de pouvoir transmettre une fiche');
+    }
+  }
   let existingCarcasse = await prisma.carcasse.findFirst({
     where: {
       zacharie_carcasse_id: zacharie_carcasse_id,

--- a/api-express/src/utils/sync-fei.ts
+++ b/api-express/src/utils/sync-fei.ts
@@ -1,6 +1,6 @@
 import prisma from '~/prisma';
 import { sanitize } from '~/utils/sanitize';
-import { EntityRelationType, Prisma, User, UserRoles } from '@prisma/client';
+import { EntityRelationType, FeiOwnerRole, Prisma, User, UserRoles } from '@prisma/client';
 import { feiPopulatedInclude } from '~/types/fei';
 import type { FeiPopulated } from '~/types/fei';
 import { capture } from '~/third-parties/sentry';
@@ -83,8 +83,9 @@ export async function syncFei(
   });
 
   if (!existingFei) {
-    const isExaminateurInitial =
-      user.roles.includes(UserRoles.CHASSEUR) && !!user.numero_cfei && !!user.activated;
+    // Un chasseur formé (numéro CFEI) peut créer une fiche même si son compte n'est pas
+    // encore activé : il peut la préparer, mais pas la transmettre (voir gate ci-dessous).
+    const isExaminateurInitial = user.roles.includes(UserRoles.CHASSEUR) && !!user.numero_cfei;
     if (!isExaminateurInitial) {
       capture(new Error('Tentative de hack: seul un examinateur initial peut créer une fiche'), {
         extra: {
@@ -94,6 +95,24 @@ export async function syncFei(
         user,
       });
       throw new Error('Seul un examinateur initial peut créer une fiche');
+    }
+  }
+
+  // Tant que le compte n'est pas activé (CFEI non validé), l'examinateur initial peut
+  // préparer la fiche mais pas la transmettre : on rejette toute avancée de responsabilité.
+  if (!user.activated) {
+    const assignsNextOwner =
+      !!body.fei_next_owner_role || !!body.fei_next_owner_user_id || !!body.fei_next_owner_entity_id;
+    const leavesExaminateur =
+      body.hasOwnProperty(Prisma.FeiScalarFieldEnum.fei_current_owner_role) &&
+      !!body.fei_current_owner_role &&
+      body.fei_current_owner_role !== FeiOwnerRole.EXAMINATEUR_INITIAL;
+    if (assignsNextOwner || leavesExaminateur) {
+      capture(new Error('Tentative de transmission par un compte non activé'), {
+        extra: { feiNumero: numero },
+        user,
+      });
+      throw new Error('Votre compte doit être validé avant de pouvoir transmettre une fiche');
     }
   }
 

--- a/app-local-first-react-router/src/components/CompteEnAttenteValidation.tsx
+++ b/app-local-first-react-router/src/components/CompteEnAttenteValidation.tsx
@@ -3,8 +3,8 @@ import { Alert } from '@codegouvfr/react-dsfr/Alert';
 // ----------------------------------------------------------------------------
 // Compte chasseur en attente de validation
 // Tant que l'admin n'a pas activé le compte (user.activated === false), le
-// backend rejette /sync. Le front masque donc les boutons de création et
-// désactive ceux de transmission ; ce bandeau explique pourquoi.
+// chasseur peut préparer ses fiches mais pas les transmettre : le front
+// désactive les boutons de transmission ; ce bandeau explique pourquoi.
 // ----------------------------------------------------------------------------
 export function CompteEnAttenteValidationAlert({ className = '' }: { className?: string }) {
   return (
@@ -12,7 +12,7 @@ export function CompteEnAttenteValidationAlert({ className = '' }: { className?:
       severity="info"
       className={`bg-white ${className}`}
       title="Compte en attente de validation"
-      description="Vous pourrez créer et transmettre des fiches dès que votre compte sera validé. Nous vous enverrons un mail dès qu’il sera activé."
+      description="Vous pouvez créer et préparer vos fiches, mais vous ne pourrez les transmettre qu’une fois votre compte validé. Nous vous enverrons un mail dès qu’il sera activé."
     />
   );
 }

--- a/app-local-first-react-router/src/components/FloatingNewFicheButton.tsx
+++ b/app-local-first-react-router/src/components/FloatingNewFicheButton.tsx
@@ -37,7 +37,7 @@ export default function FloatingNewFicheButton() {
   }, [shouldAnimate]);
 
   const isExaminateurInitial = user?.roles.includes(UserRoles.CHASSEUR) && !!user.numero_cfei;
-  if (isHiddenPage || !isExaminateurInitial || !user?.activated) return null;
+  if (isHiddenPage || !isExaminateurInitial) return null;
 
   const visible = shouldAnimate ? hasScrolled : true;
 

--- a/app-local-first-react-router/src/routes/chasseur/chasseur-fei-envoyée.tsx
+++ b/app-local-first-react-router/src/routes/chasseur/chasseur-fei-envoyée.tsx
@@ -177,7 +177,7 @@ export default function ChasseurFeiEnvoyée() {
               >
                 Voir toutes les fiches
               </Button>
-              {!!user.numero_cfei && user.activated && (
+              {!!user.numero_cfei && (
                 <Button
                   type="button"
                   // className="bg-white"

--- a/app-local-first-react-router/src/routes/chasseur/chasseur-fei.tsx
+++ b/app-local-first-react-router/src/routes/chasseur/chasseur-fei.tsx
@@ -27,6 +27,7 @@ import ExaminateurInitialDeleteFei from './examinateur-initial-delete-fei';
 import DateHeureValidationAlerts from '@app/components/DateHeureValidationAlerts';
 import ChasseurHeaderFiche from './chasseur-header-fiche';
 import CurrentOwnerConfirm from './chasseur-current-owner-confirm';
+import { CompteEnAttenteValidationAlert } from '@app/components/CompteEnAttenteValidation';
 
 export default function ChasseurFei() {
   const params = useParams();
@@ -300,6 +301,10 @@ function FEIChasseurLoaded() {
   const showBloc4 = showBloc3;
 
   const handleTransmettre = () => {
+    // Compte pas encore activé (CFEI non validé) : la fiche peut être préparée mais pas transmise.
+    if (!user.activated) {
+      return;
+    }
     if (validationErrors.length > 0) {
       setShowErrors(true);
       window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -367,10 +372,11 @@ function FEIChasseurLoaded() {
   );
 
   const submitIsDisabled = useMemo(() => {
+    if (!user.activated) return true;
     if (!showBloc4) return true;
     if (carcassesDejaEnvoyees.length === carcasses.length) return true;
     return false;
-  }, [showBloc4, carcassesDejaEnvoyees.length, carcasses.length]);
+  }, [user.activated, showBloc4, carcassesDejaEnvoyees.length, carcasses.length]);
 
   return (
     <>
@@ -709,6 +715,7 @@ function FEIChasseurLoaded() {
                   )}
                 </div>
               )}
+              {canEdit && !user.activated && <CompteEnAttenteValidationAlert className="mx-4 mb-4 md:mx-0" />}
               <div className="flex flex-col items-center justify-between px-4 py-3 md:flex-row md:px-0">
                 <div className="grid w-full grid-cols-2 grid-rows-2 gap-2 md:grid-cols-3">
                   <Button

--- a/app-local-first-react-router/src/routes/chasseur/chasseur-fiches.tsx
+++ b/app-local-first-react-router/src/routes/chasseur/chasseur-fiches.tsx
@@ -756,7 +756,7 @@ export default function ChasseurFiches() {
               </span>
             )}
           </button>
-          {user.numero_cfei && user.activated && (
+          {user.numero_cfei && (
             <Button
               iconId="fr-icon-add-circle-line"
               priority="primary"
@@ -838,7 +838,7 @@ export default function ChasseurFiches() {
                   storageKey="chasseur-fiches-export-columns"
                 />
               </div>
-              {user.numero_cfei && user.activated && (
+              {user.numero_cfei && (
                 <Button
                   iconId="fr-icon-add-circle-line"
                   priority="primary"
@@ -911,7 +911,7 @@ function FeisWrapper({
           <div className="fr-py-0 fr-col-12 fr-col-md-6">
             <div className="flex flex-col bg-white">
               <h2 className="fr-h4 mb-3 font-bold text-gray-800">Pas encore de fiches cette saison</h2>
-              {user.numero_cfei && user.activated ? (
+              {user.numero_cfei ? (
                 <>
                   <p className="fr-text--regular mb-6 max-w-md">
                     Vos fiches apparaîtront ici dès que vous aurez créé votre première fiche d'examen initial.

--- a/app-local-first-react-router/src/routes/chasseur/chasseur-layout.tsx
+++ b/app-local-first-react-router/src/routes/chasseur/chasseur-layout.tsx
@@ -76,7 +76,7 @@ export default function ChasseurLayout() {
       <FloatingNewFicheButton />
       <BottomNavigation
         items={navigation}
-        onNewFiche={isExaminateurInitial && user.activated ? onNewFiche : undefined}
+        onNewFiche={isExaminateurInitial ? onNewFiche : undefined}
       />
       {import.meta.env.VITE_TEST_PLAYWRIGHT === 'true' && (
         <p className="text-action-high-blue-france text-opacity-25 pointer-events-none fixed right-0 bottom-16 left-0 z-50 bg-white px-4 py-1 text-sm md:bottom-0">

--- a/app-local-first-react-router/src/routes/chasseur/examinateur-select-next.tsx
+++ b/app-local-first-react-router/src/routes/chasseur/examinateur-select-next.tsx
@@ -17,7 +17,6 @@ import { usePrefillPremierDétenteurInfos } from '@app/utils/usePrefillPremierD�
 import { useEntitiesIdsWorkingDirectlyFor, useDetenteursInitiaux } from '@app/utils/get-entity-relations';
 import { CarcasseTransmission } from '@app/types/carcasse';
 import { useCarcassesForFei } from '@app/utils/get-carcasses-for-fei';
-import { CompteEnAttenteValidationAlert } from '@app/components/CompteEnAttenteValidation';
 
 export default function SelectNextForExaminateur({
   disabled = false,
@@ -103,12 +102,7 @@ export default function SelectNextForExaminateur({
     return null;
   }
 
-  const notActivated = !user.activated;
-
   function handleSubmitFromSelect(nextOwnerUserId?: string) {
-    if (notActivated) {
-      return;
-    }
     const nextIsMe = nextOwnerUserId === user.id;
     const nextIsMyAssociation = !!nextOwnerEntity?.id;
     let nextFei: Partial<typeof fei>;
@@ -192,7 +186,6 @@ export default function SelectNextForExaminateur({
   return (
     <>
       <label className="mb-1 block">Premier détenteur&nbsp;*</label>
-      {notActivated && <CompteEnAttenteValidationAlert className="mb-4" />}
       {isFirstFei &&
       !Object.values(associationsDeChasse).length &&
       !Object.values(detenteursInitiaux).length ? (
@@ -219,7 +212,6 @@ export default function SelectNextForExaminateur({
                 <Button
                   priority="tertiary"
                   type="button"
-                  disabled={notActivated}
                   onClick={() => handleSubmitFromSelect(user.id)}
                 >
                   Je suis le Premier Détenteur
@@ -328,7 +320,7 @@ export default function SelectNextForExaminateur({
             <>
               <Button
                 type="button"
-                disabled={disabled || notActivated}
+                disabled={disabled}
                 onClick={() => {
                   if (validationErrors.length > 0) {
                     setShowValidationErrors(true);

--- a/app-local-first-react-router/src/routes/chasseur/premier-detenteur-select-next.tsx
+++ b/app-local-first-react-router/src/routes/chasseur/premier-detenteur-select-next.tsx
@@ -20,6 +20,7 @@ import useUser from '@app/zustand/user';
 import useZustandStore from '@app/zustand/store';
 import { syncData } from '@app/utils/sync-data';
 import { useCarcassesForFei } from '@app/utils/get-carcasses-for-fei';
+import { CompteEnAttenteValidationAlert } from '@app/components/CompteEnAttenteValidation';
 import { formatCarcasseLotCount } from '@app/utils/count-carcasses';
 import {
   useCcgIds,
@@ -134,6 +135,15 @@ function DispatchGroupForm({
   }, [prochainDetenteurType]);
 
   const Component = canEdit ? Input : InputNotEditable;
+
+  // Progressive display: reveal each input only once the previous step is filled.
+  // In read-only mode (!canEdit) everything is shown.
+  const showDepot = !canEdit || !!group.recipientEntityId;
+  const depotComplete =
+    !canEdit ||
+    group.depotType === DepotType.AUCUN ||
+    (group.depotType === DepotType.CCG && !!group.depotEntityId && !!group.depotDate);
+  const showTransport = needTransport && (!canEdit || (showDepot && depotComplete));
 
   // Only surface a field's error once the user has attempted to submit.
   const errorFor = (key: keyof GroupFieldErrors) => (showErrors ? fieldErrors[key] : undefined);
@@ -285,46 +295,48 @@ function DispatchGroupForm({
           description={`${prochainDetenteur?.nom_d_usage} n'est pas prêt pour Zacharie. Vous pouvez contacter un représentant avant de leur envoyer leur première fiche.`}
         />
       )}
-      <RadioButtons
-        legend="Lieu de stockage des carcasses *"
-        className={canEdit ? '' : 'radio-black'}
-        disabled={!group.recipientEntityId}
-        state={errorFor('depotType') ? 'error' : 'default'}
-        stateRelatedMessage={errorFor('depotType')}
-        options={[
-          {
-            label: <span className="inline-block">Pas de stockage</span>,
-            hintText: (
-              <span>
-                Sans stockage en chambre froide, les carcasses doivent être transportées{' '}
-                <b>le jour-même du tir</b>
-              </span>
-            ),
-            nativeInputProps: {
-              checked: group.depotType === DepotType.AUCUN,
-              readOnly: !canEdit,
-              onChange: () => {
-                onUpdateGroup(group.id, {
-                  depotType: DepotType.AUCUN,
-                  depotDate: undefined,
-                  depotEntityId: null,
-                });
+      {showDepot && (
+        <RadioButtons
+          legend="Lieu de stockage des carcasses *"
+          className={canEdit ? '' : 'radio-black'}
+          state={errorFor('depotType') ? 'error' : 'default'}
+          stateRelatedMessage={errorFor('depotType')}
+          options={[
+            {
+              label: <span className="inline-block">Pas de stockage</span>,
+              hintText: (
+                <span>
+                  Sans stockage en chambre froide, les carcasses doivent être transportées{' '}
+                  <b>le jour-même du tir</b>
+                </span>
+              ),
+              nativeInputProps: {
+                checked: group.depotType === DepotType.AUCUN,
+                readOnly: !canEdit,
+                onChange: () => {
+                  onUpdateGroup(group.id, {
+                    depotType: DepotType.AUCUN,
+                    depotDate: undefined,
+                    depotEntityId: null,
+                  });
+                },
               },
             },
-          },
-          {
-            label: 'Carcasses déposées dans un Centre de Collecte du Gibier sauvage (chambre froide)',
-            nativeInputProps: {
-              checked: group.depotType === DepotType.CCG,
-              readOnly: !canEdit,
-              onChange: () => {
-                onUpdateGroup(group.id, { depotType: DepotType.CCG });
+            {
+              label: 'Carcasses déposées dans un Centre de Collecte du Gibier sauvage (chambre froide)',
+              nativeInputProps: {
+                checked: group.depotType === DepotType.CCG,
+                readOnly: !canEdit,
+                onChange: () => {
+                  onUpdateGroup(group.id, { depotType: DepotType.CCG });
+                },
               },
             },
-          },
-        ]}
-      />
-      {group.depotType === DepotType.CCG &&
+          ]}
+        />
+      )}
+      {showDepot &&
+        group.depotType === DepotType.CCG &&
         (ccgsWorkingWith.length > 0 ? (
           <>
             <div>
@@ -425,12 +437,11 @@ function DispatchGroupForm({
             </Button>
           </div>
         ))}
-      {needTransport && (
+      {showTransport && (
         <>
           <RadioButtons
             legend="Transport des carcasses jusqu'au destinataire *"
             className={canEdit ? '' : 'radio-black'}
-            disabled={!group.recipientEntityId}
             state={errorFor('transportType') ? 'error' : 'default'}
             stateRelatedMessage={errorFor('transportType')}
             options={[
@@ -961,7 +972,13 @@ export default function DestinatairePremierDetenteur({
     return `Transmettre ${formatCarcasseLotCount(carcassesToSend)} sur ${formatCarcasseLotCount(allCarcasses)}`;
   }, [carcassesDejaEnvoyees.length, totalCarcassesToSend, allCarcasses, carcassesToSend]);
 
+  const notActivated = !user.activated;
+
   const handleSubmit = () => {
+    // Compte pas encore activé (CFEI non validé) : préparation autorisée, transmission bloquée.
+    if (notActivated) {
+      return;
+    }
     // Process each dispatch group
     for (const group of dispatchGroups) {
       if (!group.recipientEntityId) continue;
@@ -1215,6 +1232,7 @@ export default function DestinatairePremierDetenteur({
                 );
               })()}
 
+            {canEdit && notActivated && <CompteEnAttenteValidationAlert className="mt-4" />}
             <div className="mt-4 flex flex-col items-start justify-between gap-2 md:flex-row md:items-center">
               {/* Submit button */}
               {canEdit && !hideSubmitButton && (
@@ -1222,7 +1240,7 @@ export default function DestinatairePremierDetenteur({
                   className=""
                   type="submit"
                   iconId="fr-icon-send-plane-line"
-                  disabled={disabled || totalCarcassesToSend === 0}
+                  disabled={disabled || totalCarcassesToSend === 0 || notActivated}
                   nativeButtonProps={{
                     onClick: async (event) => {
                       event.preventDefault();

--- a/app-local-first-react-router/src/routes/chasseur/tableau-de-bord/chasseur-tableau-de-bord.tsx
+++ b/app-local-first-react-router/src/routes/chasseur/tableau-de-bord/chasseur-tableau-de-bord.tsx
@@ -87,7 +87,7 @@ export default function MesChasses() {
           <div className="fr-py-0 fr-col-12 fr-col-md-6">
             <div className="flex flex-col bg-white">
               <h2 className="fr-h4 mb-3 font-bold text-gray-800">Pas encore de carcasses cette saison</h2>
-              {!!me.numero_cfei && me.activated ? (
+              {!!me.numero_cfei ? (
                 <>
                   <p className="fr-text--regular mb-6 max-w-md">
                     Vos statistiques apparaîtront ici dès que vous aurez enregistré votre première fiche


### PR DESCRIPTION
Un chasseur formé (numero_cfei) peut désormais créer/préparer une fiche même si son compte n'est pas encore activé, mais la transmission reste bloquée tant que le CFEI n'est pas validé.

- Backend: relâche les gates `activated` sur la création (sync-fei), la synchro (sync.ts) et le chargement des carcasses (carcasse.ts) via une exception ciblée CHASSEUR + numero_cfei ; ajoute un gate de transmission (avancée d'ownership / next_owner) dans sync-fei et sync-carcasse.
- Frontend: points d'entrée "Nouvelle fiche" ouverts sans `activated` ; bouton "Transmettre" et formulaire de répartition désactivés + alerte "compte en attente de validation" tant que non activé.