### PR TITLE
fix: page blanche ETG après renvoi ou sous-traitance

### DIFF
--- a/app-local-first-react-router/src/components/FeiAucuneAction.tsx
+++ b/app-local-first-react-router/src/components/FeiAucuneAction.tsx
@@ -1,0 +1,28 @@
+import { Alert } from '@codegouvfr/react-dsfr/Alert';
+import { Button } from '@codegouvfr/react-dsfr/Button';
+
+// Affiché quand l'utilisateur n'a plus aucune action à effectuer sur la fiche
+// (ex: fiche renvoyée à l'expéditeur, fiche gérée par d'autres détenteurs).
+export default function FeiAucuneAction({ backTo }: { backTo: string }) {
+  return (
+    <div className="fr-container fr-container--fluid fr-my-md-14v">
+      <div className="fr-grid-row fr-grid-row-gutters fr-grid-row--center">
+        <div className="fr-col-12 fr-col-md-10 m-4 md:m-0">
+          <Alert
+            severity="info"
+            title="Aucune action à effectuer"
+            description="Vous n'avez plus d'action à effectuer sur cette fiche."
+          />
+          <div className="mt-8 flex justify-start">
+            <Button
+              priority="secondary"
+              linkProps={{ to: backTo }}
+            >
+              Voir toutes mes fiches
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app-local-first-react-router/src/routes/collecteur/collecteur-fei.tsx
+++ b/app-local-first-react-router/src/routes/collecteur/collecteur-fei.tsx
@@ -43,6 +43,7 @@ import FeiSousTraite from './collecteur-current-owner-sous-traite';
 import CarcasseIntermediaireComp from './collecteur-carcasse';
 import CurrentOwnerConfirm from './collecteur-current-owner-confirm';
 import NotFound from '@app/components/NotFound';
+import FeiAucuneAction from '@app/components/FeiAucuneAction';
 import Chargement from '@app/components/Chargement';
 import { loadData, useLoaderEffect } from '@app/utils/load-data';
 import { CarcasseTransmission } from '@app/types/carcasse';
@@ -144,7 +145,7 @@ function CollecteurFeiLoader(props: Props) {
   }, [transmission, myCarcasses.length, intermediaires, userEntityIds]);
 
   if (!showInterface) {
-    return null;
+    return <FeiAucuneAction backTo="/app/collecteur/" />;
   }
 
   return (

--- a/app-local-first-react-router/src/routes/etg/etg-current-owner-confirm.tsx
+++ b/app-local-first-react-router/src/routes/etg/etg-current-owner-confirm.tsx
@@ -3,6 +3,7 @@ import { Button } from '@codegouvfr/react-dsfr/Button';
 import { Alert } from '@codegouvfr/react-dsfr/Alert';
 import { useMemo, useState } from 'react';
 import dayjs from 'dayjs';
+import { toast } from 'react-toastify';
 import {
   DepotType,
   EntityRelationType,
@@ -474,6 +475,7 @@ export default function CurrentOwnerConfirm() {
                   history: createHistoryInput(currentTransmission, nextTransmission),
                 });
                 syncData('current-owner-renvoi');
+                toast.success("La fiche a été renvoyée à l'expéditeur");
               }}
             >
               Je renvoie la fiche à l'expéditeur

--- a/app-local-first-react-router/src/routes/etg/etg-destinataire-select-sous-traite.tsx
+++ b/app-local-first-react-router/src/routes/etg/etg-destinataire-select-sous-traite.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Prisma, EntityTypes, EntityRelationType, FeiOwnerRole } from '@prisma/client';
 import dayjs from 'dayjs';
+import { toast } from 'react-toastify';
 import { Alert } from '@codegouvfr/react-dsfr/Alert';
 import useUser from '@app/zustand/user';
 import useZustandStore from '@app/zustand/store';
@@ -147,6 +148,7 @@ export default function DestinataireSousTraite({
       intermediaire_id: null,
     });
     syncData('current-owner-sous-traite-select-destinataire-sous-traite');
+    toast.success(`${entities[prochainDetenteurEntityId]?.nom_d_usage ?? 'Le transporteur'} a été notifié`);
   };
 
   const jobIsMissing = useMemo(() => {

--- a/app-local-first-react-router/src/routes/etg/etg-fei.tsx
+++ b/app-local-first-react-router/src/routes/etg/etg-fei.tsx
@@ -44,6 +44,7 @@ import CarcasseIntermediaireComp from './etg-carcasse';
 import RequestNewCarcasseButton from '@app/components/RequestNewCarcasseForm';
 import CurrentOwnerConfirm from './etg-current-owner-confirm';
 import NotFound from '@app/components/NotFound';
+import FeiAucuneAction from '@app/components/FeiAucuneAction';
 import Chargement from '@app/components/Chargement';
 import { loadData, useLoaderEffect } from '@app/utils/load-data';
 import { CarcasseTransmission } from '@app/types/carcasse';
@@ -87,6 +88,7 @@ export default function EtgFei(props: Props) {
 function EtgFeiLoader(props: Props) {
   const user = useUser((state) => state.user)!;
   const entities = useZustandStore((state) => state.entities);
+  const etgsIds = useEtgIds();
   const transmissionWithMetadata = useGetTransmissionFromURLParams();
   const intermediaires = transmissionWithMetadata.intermediaires;
   const myCarcasses = transmissionWithMetadata.carcasses;
@@ -144,11 +146,19 @@ function EtgFeiLoader(props: Props) {
         return userWasIntermediaire.intermediaire_role;
       }
     }
+    // La fiche a été sous-traitée par mon entité : je n'ai plus d'action mais je dois
+    // pouvoir consulter la fiche (elle reste dans ma liste « En cours »).
+    if (
+      transmission.next_owner_sous_traite_by_entity_id &&
+      etgsIds.includes(transmission.next_owner_sous_traite_by_entity_id)
+    ) {
+      return FeiOwnerRole.ETG;
+    }
     return null;
-  }, [transmission, myCarcasses.length, user.id, intermediaires]);
+  }, [transmission, myCarcasses.length, user.id, intermediaires, etgsIds]);
 
   if (!showInterface) {
-    return null;
+    return <FeiAucuneAction backTo="/app/etg/" />;
   }
 
   return (
@@ -420,6 +430,17 @@ function EtgFeiContent({
     return true;
   }, [transmission, user, intermediaire, isEtgWorkingFor]);
   const effectiveCanEditCarcasseDecision = canEditCarcasseDecision && !props.readOnly;
+
+  // La fiche a été sous-traitée par mon entité : affichage lecture seule + rappel du transporteur choisi.
+  const feiSousTraiteeParMoi = useMemo(() => {
+    if (!transmission.next_owner_sous_traite_by_entity_id) {
+      return false;
+    }
+    return etgsIds.includes(transmission.next_owner_sous_traite_by_entity_id);
+  }, [transmission.next_owner_sous_traite_by_entity_id, etgsIds]);
+  const sousTraitantName = transmission.next_owner_entity_id
+    ? (entities[transmission.next_owner_entity_id]?.nom_d_usage ?? '')
+    : '';
 
   const formattedPriseEnChargeAt = priseEnChargeAt
     ? dayjs(priseEnChargeAt).format('YYYY-MM-DDTHH:mm')
@@ -693,6 +714,16 @@ function EtgFeiContent({
             key={transmission.current_owner_entity_id! + transmission.current_owner_user_id!}
           >
             <EtgHeaderFiche />
+            {feiSousTraiteeParMoi && (
+              <div className="bg-alt-blue-france pb-8">
+                <Alert
+                  severity="info"
+                  className="bg-white"
+                  title={`Transport sous-traité${sousTraitantName ? ` : ${sousTraitantName}` : ''}`}
+                  description="Vous avez sous-traité le transport de ces carcasses, vous n'avez plus d'action à effectuer sur cette fiche."
+                />
+              </div>
+            )}
             <FeiSousTraite />
             <CurrentOwnerConfirm />
             {/* <Section title="Transport" key={intermediaire?.id}>


### PR DESCRIPTION
Quand l'ETG renvoie la fiche à l'expéditeur ou sous-traite le transport, il sort de la chaîne de la transmission : showInterface devenait null et la page n'affichait plus que header/footer.

- nouveau composant FeiAucuneAction (message neutre + bouton retour) à la place du `return null` dans etg-fei et collecteur-fei
- sous-traitance : branche dédiée dans showInterface pour afficher la fiche en lecture seule + bandeau rappelant le transporteur choisi
- toasts de confirmation au renvoi et à la sous-traitance