### PR TITLE
fix: carte carcasse lit désormais l'état de possession de la carcasse

### DIFF
--- a/app-local-first-react-router/src/components/CardCarcasse.tsx
+++ b/app-local-first-react-router/src/components/CardCarcasse.tsx
@@ -83,7 +83,7 @@ export default function CardCarcasse({
     return commentaires;
   }, [carcassesIntermediaires, entities]);
 
-  const { statusNewCard, motifRefus } = useCarcasseStatusAndRefus(carcasse, fei);
+  const { statusNewCard, motifRefus } = useCarcasseStatusAndRefus(carcasse);
 
   let miseAMort = '';
   if (!hideDateMiseAMort) {
@@ -126,7 +126,6 @@ export default function CardCarcasse({
 
   const cardDisplay = getCarcasseCardDisplay({
     carcasse,
-    fei,
     latestIntermediaire,
     entities,
     viewRole,

--- a/app-local-first-react-router/src/routes/chasseur/examinateur-carcasse-detail.tsx
+++ b/app-local-first-react-router/src/routes/chasseur/examinateur-carcasse-detail.tsx
@@ -409,12 +409,11 @@ function ExaminateurCarcasseDetailLoaded() {
     () =>
       getCarcasseCardDisplay({
         carcasse,
-        fei,
         latestIntermediaire: intermediaires[0],
         entities,
         viewRole,
       }),
-    [carcasse, fei, intermediaires, entities]
+    [carcasse, intermediaires, entities]
   );
   const headerStatusLabel = cardDisplay.statusLabel ?? 'En cours de création';
   const headerAccentColor: CardAccent = cardDisplay.accentColor ?? 'gray';

--- a/app-local-first-react-router/src/utils/get-carcasse-card-display.test.ts
+++ b/app-local-first-react-router/src/utils/get-carcasse-card-display.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { Carcasse, CarcasseStatus, CarcasseType, FeiOwnerRole } from '@prisma/client';
+import { deriveCarcasseUiState, getCarcasseCardDisplay } from './get-carcasse-card-display';
+
+// Minimal carcasse factory — only the fields the ui-state logic reads.
+function c(overrides: Partial<Carcasse> = {}): Carcasse {
+  return {
+    zacharie_carcasse_id: 'FEI-TEST_MM-001-001',
+    fei_numero: 'FEI-TEST',
+    type: CarcasseType.GROS_GIBIER,
+    svi_ipm1_date: null,
+    svi_ipm2_date: null,
+    svi_carcasse_status: CarcasseStatus.SANS_DECISION,
+    current_owner_role: null,
+    next_owner_role: null,
+    ...overrides,
+  } as unknown as Carcasse;
+}
+
+const noEntities = {} as Parameters<typeof getCarcasseCardDisplay>[0]['entities'];
+
+describe('deriveCarcasseUiState — possession lue au niveau carcasse', () => {
+  it('carcasse encore chez le premier détenteur sans prochain détenteur → "creation"', () => {
+    const carcasse = c({
+      current_owner_role: FeiOwnerRole.PREMIER_DETENTEUR,
+      next_owner_role: null,
+    });
+    expect(deriveCarcasseUiState(carcasse, undefined, {})).toBe('creation');
+  });
+
+  it('carcasse chez l\'examinateur initial sans prochain détenteur → "creation"', () => {
+    const carcasse = c({
+      current_owner_role: FeiOwnerRole.EXAMINATEUR_INITIAL,
+      next_owner_role: null,
+    });
+    expect(deriveCarcasseUiState(carcasse, undefined, {})).toBe('creation');
+  });
+
+  it('carcasse transmise à un ETG (next_owner = ETG) → "transmise"', () => {
+    const carcasse = c({
+      current_owner_role: FeiOwnerRole.PREMIER_DETENTEUR,
+      next_owner_role: FeiOwnerRole.ETG,
+    });
+    expect(deriveCarcasseUiState(carcasse, undefined, {})).toBe('transmise');
+  });
+
+  // Régression : après un « Retour à l'envoyeur » d'un ETG, seul next_owner_role de la
+  // carcasse repasse à null. La carte doit lire la carcasse (et non le snapshot FEI périmé)
+  // → l'état repasse à "creation", actionnable, et non "transmise".
+  it('carcasse renvoyée par l\'ETG (next_owner repassé à null) → "creation"', () => {
+    const carcasse = c({
+      current_owner_role: FeiOwnerRole.PREMIER_DETENTEUR,
+      next_owner_role: null,
+    });
+    expect(deriveCarcasseUiState(carcasse, undefined, {})).toBe('creation');
+  });
+});
+
+describe('getCarcasseCardDisplay — vue chasseur', () => {
+  it('carcasse transmise → libellé "En cours de traitement"', () => {
+    const carcasse = c({
+      current_owner_role: FeiOwnerRole.PREMIER_DETENTEUR,
+      next_owner_role: FeiOwnerRole.ETG,
+    });
+    const display = getCarcasseCardDisplay({
+      carcasse,
+      latestIntermediaire: undefined,
+      entities: noEntities,
+      viewRole: 'chasseur',
+    });
+    expect(display.uiState).toBe('transmise');
+    expect(display.statusLabel).toBe('En cours de traitement');
+  });
+
+  it('carcasse renvoyée par l\'ETG → plus de "En cours de traitement"', () => {
+    const carcasse = c({
+      current_owner_role: FeiOwnerRole.PREMIER_DETENTEUR,
+      next_owner_role: null,
+    });
+    const display = getCarcasseCardDisplay({
+      carcasse,
+      latestIntermediaire: undefined,
+      entities: noEntities,
+      viewRole: 'chasseur',
+    });
+    expect(display.uiState).toBe('creation');
+    expect(display.statusLabel).toBeNull();
+  });
+});

--- a/app-local-first-react-router/src/utils/get-carcasse-card-display.ts
+++ b/app-local-first-react-router/src/utils/get-carcasse-card-display.ts
@@ -26,7 +26,6 @@ export interface CardDisplay {
 
 export interface CardDisplayParams {
   carcasse: Carcasse;
-  fei: ReturnType<typeof useZustandStore.getState>['feis'][string];
   latestIntermediaire: ReturnType<typeof useCarcassesIntermediairesForCarcasse>[number] | undefined;
   entities: ReturnType<typeof useZustandStore.getState>['entities'];
   viewRole: CardViewRole;
@@ -37,7 +36,6 @@ export interface CardDisplayParams {
 
 export function deriveCarcasseUiState(
   carcasse: Carcasse,
-  fei: CardDisplayParams['fei'],
   latestIntermediaire: CardDisplayParams['latestIntermediaire'],
   overrides: { forceRefus?: boolean; forceManquante?: boolean; forceAccept?: boolean }
 ): CardUiState {
@@ -67,10 +65,12 @@ export function deriveCarcasseUiState(
     case CarcasseStatus.TRAITEMENT_ASSAINISSANT:
       return 'accepte-svi';
     case CarcasseStatus.SANS_DECISION: {
+      // On lit l'état de possession de la carcasse elle-même (source de vérité),
+      // pas le snapshot FEI qui peut être périmé après un « Retour à l'envoyeur ».
       const isCreation =
-        (fei?.fei_current_owner_role === FeiOwnerRole.EXAMINATEUR_INITIAL ||
-          fei?.fei_current_owner_role === FeiOwnerRole.PREMIER_DETENTEUR) &&
-        !fei?.fei_next_owner_role;
+        (carcasse.current_owner_role === FeiOwnerRole.EXAMINATEUR_INITIAL ||
+          carcasse.current_owner_role === FeiOwnerRole.PREMIER_DETENTEUR) &&
+        !carcasse.next_owner_role;
       if (isCreation) return 'creation';
       if (latestIntermediaire?.decision_at && latestIntermediaire?.intermediaire_role === FeiOwnerRole.ETG) {
         return 'acceptee-etg';
@@ -86,10 +86,10 @@ export function deriveCarcasseUiState(
 }
 
 export function getCarcasseCardDisplay(params: CardDisplayParams): CardDisplay {
-  const { carcasse, fei, latestIntermediaire, entities, viewRole, forceRefus, forceManquante, forceAccept } =
+  const { carcasse, latestIntermediaire, entities, viewRole, forceRefus, forceManquante, forceAccept } =
     params;
 
-  const uiState = deriveCarcasseUiState(carcasse, fei, latestIntermediaire, {
+  const uiState = deriveCarcasseUiState(carcasse, latestIntermediaire, {
     forceRefus,
     forceManquante,
     forceAccept,

--- a/app-local-first-react-router/src/utils/useCarcasseStatusAndRefus.tsx
+++ b/app-local-first-react-router/src/utils/useCarcasseStatusAndRefus.tsx
@@ -1,11 +1,11 @@
-import { Carcasse, CarcasseStatus, CarcasseType, Fei, FeiOwnerRole } from '@prisma/client';
+import { Carcasse, CarcasseStatus, CarcasseType, FeiOwnerRole } from '@prisma/client';
 import { useMemo } from 'react';
 import useZustandStore from '@app/zustand/store';
 import { getVulgarisationSaisie } from '@app/utils/get-vulgarisation-saisie';
 import { getSimplifiedCarcasseStatus } from '@app/utils/get-carcasse-status';
 import { getFeiAndCarcasseAndIntermediaireIdsFromCarcasse } from './get-carcasse-intermediaire-id';
 
-export function useCarcasseStatusAndRefus(carcasse: Carcasse, fei: Fei) {
+export function useCarcasseStatusAndRefus(carcasse: Carcasse) {
   const entities = useZustandStore((state) => state.entities);
   const carcassesIntermediaires = useZustandStore((state) => state.carcassesIntermediaireById);
 
@@ -15,16 +15,18 @@ export function useCarcasseStatusAndRefus(carcasse: Carcasse, fei: Fei) {
     | 'refusé'
     | 'accepté'
     | 'saisie partielle' = useMemo(() => {
+    // On lit l'état de possession de la carcasse elle-même (source de vérité),
+    // pas le snapshot FEI qui peut être périmé après un « Retour à l'envoyeur ».
     if (
-      fei.fei_current_owner_role === FeiOwnerRole.EXAMINATEUR_INITIAL ||
-      fei.fei_current_owner_role === FeiOwnerRole.PREMIER_DETENTEUR
+      carcasse.current_owner_role === FeiOwnerRole.EXAMINATEUR_INITIAL ||
+      carcasse.current_owner_role === FeiOwnerRole.PREMIER_DETENTEUR
     ) {
-      if (!fei.fei_next_owner_role) {
+      if (!carcasse.next_owner_role) {
         return 'en cours de création';
       }
     }
     return getSimplifiedCarcasseStatus(carcasse);
-  }, [carcasse, fei.fei_current_owner_role, fei.fei_next_owner_role]);
+  }, [carcasse]);
 
   const motifRefus: string = useMemo(() => {
     switch (carcasse.svi_carcasse_status) {


### PR DESCRIPTION
…itement"

La carte carcasse lit désormais l'état de possession de la carcasse (current_owner_role / next_owner_role) au lieu du snapshot FEI, qui reste périmé après un "Retour à l'envoyeur". Une carcasse revenue au premier détenteur repasse ainsi à l'état actionnable au lieu de "en cours de traitement".