### PR TITLE
fix: carcasse-sync-merge-conflict

### DIFF
--- a/app-local-first-react-router/src/routes/etg/etg-current-owner-confirm.tsx
+++ b/app-local-first-react-router/src/routes/etg/etg-current-owner-confirm.tsx
@@ -25,10 +25,12 @@ import { useGetTransmissionFromURLParams } from '@app/utils/get-transmissions-so
 export default function CurrentOwnerConfirm() {
   const user = useUser((state) => state.user)!;
   const updateCarcassesTransmission = useZustandStore((state) => state.updateCarcassesTransmission);
+  const updateFei = useZustandStore((state) => state.updateFei);
   const createCarcassesIntermediaire = useZustandStore((state) => state.createCarcassesIntermediaire);
   const addLog = useZustandStore((state) => state.addLog);
   const transmissionMetadata = useGetTransmissionFromURLParams();
   const fei = transmissionMetadata.fei;
+  const feis = useZustandStore((state) => state.feis);
   const entities = useZustandStore((state) => state.entities);
   const users = useZustandStore((state) => state.users);
   const myCarcasses = transmissionMetadata.carcasses;
@@ -460,6 +462,18 @@ export default function CurrentOwnerConfirm() {
                   next_owner_role: null,
                 };
                 updateCarcassesTransmission(myCarcasseIds, nextTransmission);
+                // Le snapshot FEI (déprécié) pointait encore sur nous : on le vide en miroir du
+                // next_owner carcasse. Sinon, au ré-envoi du chasseur, `fei_next_owner_entity_id`
+                // resterait inchangé (ETG → ETG) et `notifyNextOwnerEntity` ne nous re-notifierait pas.
+                if (feis[fei.numero]?.fei_next_owner_entity_id === currentTransmission.next_owner_entity_id) {
+                  updateFei(fei.numero, {
+                    fei_next_owner_entity_id: null,
+                    fei_next_owner_entity_name_cache: null,
+                    fei_next_owner_user_id: null,
+                    fei_next_owner_user_name_cache: null,
+                    fei_next_owner_role: null,
+                  });
+                }
                 addLog({
                   user_id: user.id,
                   user_role: currentTransmission.next_owner_role as UserRoles,

--- a/app-local-first-react-router/src/utils/merge-fetched-items.test.ts
+++ b/app-local-first-react-router/src/utils/merge-fetched-items.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { mergeItems } from './merge-fetched-items';
+
+type Item = {
+  id: string;
+  value: string;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at?: Date | null;
+  is_synced?: boolean;
+};
+
+const idKey = (i: Item) => i.id;
+
+function item(overrides: Partial<Item> = {}): Item {
+  return {
+    id: 'a',
+    value: 'server',
+    created_at: new Date('2026-01-01'),
+    updated_at: new Date('2026-01-01'),
+    deleted_at: null,
+    is_synced: true,
+    ...overrides,
+  };
+}
+
+describe('mergeItems', () => {
+  it('la version serveur gagne quand le local est synchronisé', () => {
+    const oldItems = [item({ id: 'a', value: 'local', is_synced: true })];
+    const newItems = [item({ id: 'a', value: 'server', is_synced: true })];
+    const merged = mergeItems({ oldItems, newItems, idKey }) as Record<string, Item>;
+    expect(merged['a'].value).toBe('server');
+  });
+
+  // Régression : un ré-envoi de carcasse pose une modif locale non synchronisée et plus récente.
+  // Un pull concurrent (qui revoit encore l'ancien état serveur, donc plus ancien) ne doit PAS
+  // écraser cette modif, sinon le ré-envoi est perdu et la carcasse reste bloquée chez le premier
+  // détenteur.
+  it('ne pas écraser un item local non synchronisé PLUS RÉCENT que le serveur', () => {
+    const oldItems = [
+      item({ id: 'a', value: 'local-non-synced', is_synced: false, updated_at: new Date('2026-03-02') }),
+    ];
+    const newItems = [
+      item({ id: 'a', value: 'server-stale', is_synced: true, updated_at: new Date('2026-03-01') }),
+    ];
+    const merged = mergeItems({ oldItems, newItems, idKey }) as Record<string, Item>;
+    expect(merged['a'].value).toBe('local-non-synced');
+    expect(merged['a'].is_synced).toBe(false);
+  });
+
+  // Après un push réussi, le serveur a rattrapé (updated_at serveur >= local) : on accepte la
+  // version serveur pour que is_synced repasse à true (sinon l'item resterait « dirty » à jamais).
+  it('accepter la version serveur quand elle a rattrapé un local non synchronisé', () => {
+    const oldItems = [
+      item({ id: 'a', value: 'local-non-synced', is_synced: false, updated_at: new Date('2026-03-01') }),
+    ];
+    const newItems = [
+      item({ id: 'a', value: 'server-caught-up', is_synced: true, updated_at: new Date('2026-03-02') }),
+    ];
+    const merged = mergeItems({ oldItems, newItems, idKey }) as Record<string, Item>;
+    expect(merged['a'].value).toBe('server-caught-up');
+    expect(merged['a'].is_synced).toBe(true);
+  });
+
+  it('ne pas supprimer un item local non synchronisé plus récent que la suppression serveur', () => {
+    const oldItems = [
+      item({ id: 'a', value: 'local-non-synced', is_synced: false, updated_at: new Date('2026-03-02') }),
+    ];
+    const newItems = [item({ id: 'a', value: 'server', deleted_at: new Date('2026-03-01') })];
+    const merged = mergeItems({ oldItems, newItems, idKey }) as Record<string, Item>;
+    expect(merged['a']).toBeDefined();
+    expect(merged['a'].value).toBe('local-non-synced');
+  });
+
+  it('un item supprimé côté serveur est retiré du merge (cas synchronisé)', () => {
+    const oldItems = [item({ id: 'a', value: 'local', is_synced: true })];
+    const newItems = [item({ id: 'a', deleted_at: new Date('2026-02-01') })];
+    const merged = mergeItems({ oldItems, newItems, idKey }) as Record<string, Item>;
+    expect(merged['a']).toBeUndefined();
+  });
+
+  it('conserve les items locaux absents de la réponse serveur', () => {
+    const oldItems = [item({ id: 'a', value: 'local-a' }), item({ id: 'b', value: 'local-b' })];
+    const newItems = [item({ id: 'a', value: 'server-a' })];
+    const merged = mergeItems({ oldItems, newItems, idKey }) as Record<string, Item>;
+    expect(merged['a'].value).toBe('server-a');
+    expect(merged['b'].value).toBe('local-b');
+  });
+
+  it('ajoute les nouveaux items serveur', () => {
+    const oldItems: Item[] = [];
+    const newItems = [item({ id: 'c', value: 'server-c' })];
+    const merged = mergeItems({ oldItems, newItems, idKey }) as Record<string, Item>;
+    expect(merged['c'].value).toBe('server-c');
+  });
+});

--- a/app-local-first-react-router/src/utils/merge-fetched-items.ts
+++ b/app-local-first-react-router/src/utils/merge-fetched-items.ts
@@ -2,6 +2,7 @@ interface ItemBase {
   created_at: Date;
   updated_at: Date;
   deleted_at?: Date | null;
+  is_synced?: boolean;
 }
 
 interface MergeParams<T extends ItemBase> {
@@ -10,21 +11,35 @@ interface MergeParams<T extends ItemBase> {
   idKey: (item: T) => string;
 }
 
+const time = (d?: Date | string | null) => (d ? new Date(d).getTime() : 0);
+
 export function mergeItems<T extends ItemBase>({ oldItems, newItems, idKey }: MergeParams<T>) {
   const toReturn = {};
-  const newItemIds = {};
   const newItemIdsDeleted = {};
 
+  const oldById: Record<string, T> = {};
+  for (const oldItem of oldItems) {
+    oldById[idKey(oldItem)] = oldItem;
+  }
+
   for (const newItem of newItems) {
-    // @ts-expect-error idKey is not a property of T
-    newItemIds[idKey(newItem)] = true;
+    const id = idKey(newItem);
+    const local = oldById[id];
+    // Local-first : une modif locale non encore poussée (`is_synced === false`) et PLUS RÉCENTE
+    // que la version serveur est la source de vérité — le pull ne doit pas l'écraser, sinon il
+    // efface une édition en attente (ex. un ré-envoi de carcasse poussé en concurrence d'un pull
+    // qui revoit encore l'ancien état serveur). Dès que le serveur a rattrapé (`updated_at` serveur
+    // >= local), on accepte la version serveur et `is_synced` repasse naturellement à true.
+    if (local && local.is_synced === false && time(local.updated_at) > time(newItem.updated_at)) {
+      continue;
+    }
     if (newItem.deleted_at) {
       // @ts-expect-error idKey is not a property of T
-      newItemIdsDeleted[idKey(newItem)] = true;
+      newItemIdsDeleted[id] = true;
       continue;
     }
     // @ts-expect-error idKey is not a property of T
-    toReturn[idKey(newItem)] = newItem;
+    toReturn[id] = newItem;
   }
 
   for (const oldItem of oldItems) {


### PR DESCRIPTION
1. Correctif principal — merge-fetched-items.ts (mergeItems)
Le pull ne peut plus écraser une modif locale non synchronisée et plus récente que la version serveur. Règle « keep-newest » ciblée : on garde le local seulement si is_synced === false et local.updated_at > server.updated_at. Dès que le serveur a rattrapé (après le push), sa version regagne et is_synced repasse bien à true (pas de boucle « dirty » perpétuelle). C'est ce qui empêche le ré-envoi de carcasse (next_owner = ETG) d'être effacé par un pull concurrent qui revoit encore l'état du renvoi (next_owner = null).

2. merge-fetched-items.test.ts (nouveau) — 7 cas, dont les régressions : local non-synchronisé plus récent non écrasé, et serveur qui a rattrapé accepté (pour que is_synced se règle).

3. Durcissement — etg-current-owner-confirm.tsx
Au renvoi, on vide aussi le snapshot FEI fei_next_owner_* (en miroir du next_owner carcasse), sous garde fei_next_owner_entity_id === next_owner_entity_id (sûr en multi-dispatch). Effet : au ré-envoi, fei_next_owner_entity_id passe null → ETG (vrai changement) → notifyNextOwnerEntity re-notifie bien l'ETG.