### PR TITLE
fix: carcasse transmise en circuit court affiche "Transmise" (vert)

### DIFF
--- a/app-local-first-react-router/src/components/CardCarcasse.tsx
+++ b/app-local-first-react-router/src/components/CardCarcasse.tsx
@@ -147,6 +147,8 @@ export default function CardCarcasse({
         return 'border-action-high-blue-france border-l-3';
       case 'orange':
         return 'border-warning-main-525 border-l-3';
+      case 'green':
+        return 'border-green-600 border-l-3';
       default:
         return '';
     }
@@ -163,6 +165,8 @@ export default function CardCarcasse({
         return 'text-warning-main-525';
       case 'gray':
         return 'text-gray-600';
+      case 'green':
+        return 'text-green-600';
       default:
         return '';
     }
@@ -325,6 +329,13 @@ function getAccentColorClasses(accent: CardAccent | undefined): DecisionColor {
         cardBg: 'bg-orange-50',
         badgeBg: 'bg-orange-100',
         badgeText: 'text-orange-800',
+      };
+    case 'green':
+      return {
+        cardText: 'text-green-700',
+        cardBg: 'bg-green-50',
+        badgeBg: 'bg-green-100',
+        badgeText: 'text-green-800',
       };
     case 'gray':
     default:

--- a/app-local-first-react-router/src/components/CardCarcasse.tsx
+++ b/app-local-first-react-router/src/components/CardCarcasse.tsx
@@ -147,8 +147,6 @@ export default function CardCarcasse({
         return 'border-action-high-blue-france border-l-3';
       case 'orange':
         return 'border-warning-main-525 border-l-3';
-      case 'green':
-        return 'border-green-600 border-l-3';
       default:
         return '';
     }
@@ -165,8 +163,6 @@ export default function CardCarcasse({
         return 'text-warning-main-525';
       case 'gray':
         return 'text-gray-600';
-      case 'green':
-        return 'text-green-600';
       default:
         return '';
     }
@@ -329,13 +325,6 @@ function getAccentColorClasses(accent: CardAccent | undefined): DecisionColor {
         cardBg: 'bg-orange-50',
         badgeBg: 'bg-orange-100',
         badgeText: 'text-orange-800',
-      };
-    case 'green':
-      return {
-        cardText: 'text-green-700',
-        cardBg: 'bg-green-50',
-        badgeBg: 'bg-green-100',
-        badgeText: 'text-green-800',
       };
     case 'gray':
     default:

--- a/app-local-first-react-router/src/routes/chasseur/chasseur-fei-carcasses.tsx
+++ b/app-local-first-react-router/src/routes/chasseur/chasseur-fei-carcasses.tsx
@@ -81,7 +81,7 @@ export default function CarcassesExaminateur({
           {Object.entries(dejaEnvoyeesParDestinataire).map(([entityId, group]) => (
             <div key={entityId}>
               <p className="mt-0 mb-2 text-sm text-gray-500">
-                Vers {entities[entityId]?.nom_d_usage ?? 'destinataire inconnu'} (
+                Envoyée à {entities[entityId]?.nom_d_usage ?? 'destinataire inconnu'} (
                 {formatCarcasseLotCount(group)})
               </p>
               <div className="grid grid-cols-1 gap-2 md:grid-cols-2">{group.map(renderCarcasseCard)}</div>

--- a/app-local-first-react-router/src/utils/circuit-court.ts
+++ b/app-local-first-react-router/src/utils/circuit-court.ts
@@ -1,7 +1,7 @@
 import useUser from '@app/zustand/user';
-import { EntityTypes, Entity, User, UserRoles } from '@prisma/client';
+import { EntityTypes, Entity, FeiOwnerRole, User, UserRoles } from '@prisma/client';
 
-export function isRoleCircuitCourt(role: UserRoles) {
+export function isRoleCircuitCourt(role: UserRoles | FeiOwnerRole | null | undefined) {
   if (!role) return false;
   return (
     role === UserRoles.COMMERCE_DE_DETAIL ||

--- a/app-local-first-react-router/src/utils/get-carcasse-card-display.test.ts
+++ b/app-local-first-react-router/src/utils/get-carcasse-card-display.test.ts
@@ -83,7 +83,7 @@ describe('getCarcasseCardDisplay — vue chasseur', () => {
     expect(display.statusLabel).toBe('En cours de traitement');
   });
 
-  it('carcasse transmise en circuit court → libellé "Transmise" (vert)', () => {
+  it('carcasse transmise en circuit court → libellé "Transmise" (bleu)', () => {
     const carcasse = c({
       current_owner_role: FeiOwnerRole.PREMIER_DETENTEUR,
       next_owner_role: FeiOwnerRole.COMMERCE_DE_DETAIL,
@@ -96,7 +96,7 @@ describe('getCarcasseCardDisplay — vue chasseur', () => {
     });
     expect(display.uiState).toBe('transmise-circuit-court');
     expect(display.statusLabel).toBe('Transmise');
-    expect(display.accentColor).toBe('green');
+    expect(display.accentColor).toBe('blue');
   });
 
   it('carcasse renvoyée par l\'ETG → plus de "En cours de traitement"', () => {

--- a/app-local-first-react-router/src/utils/get-carcasse-card-display.test.ts
+++ b/app-local-first-react-router/src/utils/get-carcasse-card-display.test.ts
@@ -44,6 +44,16 @@ describe('deriveCarcasseUiState — possession lue au niveau carcasse', () => {
     expect(deriveCarcasseUiState(carcasse, undefined, {})).toBe('transmise');
   });
 
+  // Circuit court (commerce de détail, particulier…) est un destinataire terminal :
+  // la carcasse est « Transmise », pas « en cours de traitement ».
+  it('carcasse transmise à un destinataire de circuit court → "transmise-circuit-court"', () => {
+    const carcasse = c({
+      current_owner_role: FeiOwnerRole.COMMERCE_DE_DETAIL,
+      next_owner_role: null,
+    });
+    expect(deriveCarcasseUiState(carcasse, undefined, {})).toBe('transmise-circuit-court');
+  });
+
   // Régression : après un « Retour à l'envoyeur » d'un ETG, seul next_owner_role de la
   // carcasse repasse à null. La carte doit lire la carcasse (et non le snapshot FEI périmé)
   // → l'état repasse à "creation", actionnable, et non "transmise".
@@ -70,6 +80,22 @@ describe('getCarcasseCardDisplay — vue chasseur', () => {
     });
     expect(display.uiState).toBe('transmise');
     expect(display.statusLabel).toBe('En cours de traitement');
+  });
+
+  it('carcasse transmise en circuit court → libellé "Transmise" (vert)', () => {
+    const carcasse = c({
+      current_owner_role: FeiOwnerRole.COMMERCE_DE_DETAIL,
+      next_owner_role: null,
+    });
+    const display = getCarcasseCardDisplay({
+      carcasse,
+      latestIntermediaire: undefined,
+      entities: noEntities,
+      viewRole: 'chasseur',
+    });
+    expect(display.uiState).toBe('transmise-circuit-court');
+    expect(display.statusLabel).toBe('Transmise');
+    expect(display.accentColor).toBe('green');
   });
 
   it('carcasse renvoyée par l\'ETG → plus de "En cours de traitement"', () => {

--- a/app-local-first-react-router/src/utils/get-carcasse-card-display.test.ts
+++ b/app-local-first-react-router/src/utils/get-carcasse-card-display.test.ts
@@ -44,12 +44,13 @@ describe('deriveCarcasseUiState — possession lue au niveau carcasse', () => {
     expect(deriveCarcasseUiState(carcasse, undefined, {})).toBe('transmise');
   });
 
-  // Circuit court (commerce de détail, particulier…) est un destinataire terminal :
-  // la carcasse est « Transmise », pas « en cours de traitement ».
-  it('carcasse transmise à un destinataire de circuit court → "transmise-circuit-court"', () => {
+  // Circuit court (commerce de détail, particulier…) est un destinataire terminal.
+  // Il ne « prend jamais en charge » : current_owner_role reste PREMIER_DETENTEUR et
+  // seul next_owner_role pointe vers le destinataire. La carcasse est « Transmise ».
+  it('carcasse transmise par le PD à un destinataire de circuit court → "transmise-circuit-court"', () => {
     const carcasse = c({
-      current_owner_role: FeiOwnerRole.COMMERCE_DE_DETAIL,
-      next_owner_role: null,
+      current_owner_role: FeiOwnerRole.PREMIER_DETENTEUR,
+      next_owner_role: FeiOwnerRole.COMMERCE_DE_DETAIL,
     });
     expect(deriveCarcasseUiState(carcasse, undefined, {})).toBe('transmise-circuit-court');
   });
@@ -84,8 +85,8 @@ describe('getCarcasseCardDisplay — vue chasseur', () => {
 
   it('carcasse transmise en circuit court → libellé "Transmise" (vert)', () => {
     const carcasse = c({
-      current_owner_role: FeiOwnerRole.COMMERCE_DE_DETAIL,
-      next_owner_role: null,
+      current_owner_role: FeiOwnerRole.PREMIER_DETENTEUR,
+      next_owner_role: FeiOwnerRole.COMMERCE_DE_DETAIL,
     });
     const display = getCarcasseCardDisplay({
       carcasse,

--- a/app-local-first-react-router/src/utils/get-carcasse-card-display.ts
+++ b/app-local-first-react-router/src/utils/get-carcasse-card-display.ts
@@ -16,7 +16,7 @@ export type CardUiState =
   | 'saisie-partielle'
   | 'saisie-totale'
   | 'accepte-svi';
-export type CardAccent = 'red' | 'blue' | 'orange' | 'gray' | 'green' | null;
+export type CardAccent = 'red' | 'blue' | 'orange' | 'gray' | null;
 
 export interface CardDisplay {
   uiState: CardUiState;
@@ -118,7 +118,7 @@ export function getCarcasseCardDisplay(params: CardDisplayParams): CardDisplay {
     return {
       uiState,
       iconId: 'fr-icon-checkbox-circle-line',
-      accentColor: 'green',
+      accentColor: 'blue',
       statusLabel: 'Transmise',
       showStatusLine: true,
     };

--- a/app-local-first-react-router/src/utils/get-carcasse-card-display.ts
+++ b/app-local-first-react-router/src/utils/get-carcasse-card-display.ts
@@ -1,11 +1,13 @@
 import { Carcasse, CarcasseStatus, CarcasseType, FeiOwnerRole } from '@prisma/client';
 import type useZustandStore from '@app/zustand/store';
 import type { useCarcassesIntermediairesForCarcasse } from '@app/utils/get-carcasses-intermediaires';
+import { isRoleCircuitCourt } from '@app/utils/circuit-court';
 
 export type CardViewRole = 'chasseur' | 'etg-coll' | 'svi';
 export type CardUiState =
   | 'creation'
   | 'transmise'
+  | 'transmise-circuit-court'
   | 'manquante-etg'
   | 'refusee-etg'
   | 'acceptee-etg'
@@ -14,7 +16,7 @@ export type CardUiState =
   | 'saisie-partielle'
   | 'saisie-totale'
   | 'accepte-svi';
-export type CardAccent = 'red' | 'blue' | 'orange' | 'gray' | null;
+export type CardAccent = 'red' | 'blue' | 'orange' | 'gray' | 'green' | null;
 
 export interface CardDisplay {
   uiState: CardUiState;
@@ -72,6 +74,9 @@ export function deriveCarcasseUiState(
           carcasse.current_owner_role === FeiOwnerRole.PREMIER_DETENTEUR) &&
         !carcasse.next_owner_role;
       if (isCreation) return 'creation';
+      // Circuit court (commerce de détail, particulier…) est un destinataire terminal :
+      // il n'inspecte ni ne retransmet. La carcasse est donc « Transmise » et non « en cours de traitement ».
+      if (isRoleCircuitCourt(carcasse.current_owner_role)) return 'transmise-circuit-court';
       if (latestIntermediaire?.decision_at && latestIntermediaire?.intermediaire_role === FeiOwnerRole.ETG) {
         return 'acceptee-etg';
       }
@@ -104,6 +109,16 @@ export function getCarcasseCardDisplay(params: CardDisplayParams): CardDisplay {
     ? entities[latestIntermediaire.intermediaire_entity_id]
     : null;
   const intermediaireName = intermediaireEntity?.nom_d_usage ?? '';
+
+  if (uiState === 'transmise-circuit-court') {
+    return {
+      uiState,
+      iconId: 'fr-icon-checkbox-circle-line',
+      accentColor: 'green',
+      statusLabel: 'Transmise',
+      showStatusLine: true,
+    };
+  }
 
   if (viewRole === 'chasseur') {
     if (uiState === 'creation') {

--- a/app-local-first-react-router/src/utils/get-carcasse-card-display.ts
+++ b/app-local-first-react-router/src/utils/get-carcasse-card-display.ts
@@ -75,8 +75,12 @@ export function deriveCarcasseUiState(
         !carcasse.next_owner_role;
       if (isCreation) return 'creation';
       // Circuit court (commerce de détail, particulier…) est un destinataire terminal :
-      // il n'inspecte ni ne retransmet. La carcasse est donc « Transmise » et non « en cours de traitement ».
-      if (isRoleCircuitCourt(carcasse.current_owner_role)) return 'transmise-circuit-court';
+      // il n'inspecte ni ne retransmet, donc il ne « prend jamais en charge » et
+      // current_owner_role reste PREMIER_DETENTEUR. On lit le destinataire (next_owner_role).
+      // La carcasse est « Transmise » et non « en cours de traitement ».
+      if (isRoleCircuitCourt(carcasse.next_owner_role) || isRoleCircuitCourt(carcasse.current_owner_role)) {
+        return 'transmise-circuit-court';
+      }
       if (latestIntermediaire?.decision_at && latestIntermediaire?.intermediaire_role === FeiOwnerRole.ETG) {
         return 'acceptee-etg';
       }

--- a/app-local-first-react-router/src/utils/is-carcasse-done.test.ts
+++ b/app-local-first-react-router/src/utils/is-carcasse-done.test.ts
@@ -97,6 +97,18 @@ describe('isCarcasseDone', () => {
     expect(isCarcasseDone(c({ consommateur_final_usage_domestique: new Date() }))).toBe(true);
   });
 
+  it('true when transmise à un destinataire de circuit court (next_owner_role)', () => {
+    // current_owner reste PREMIER_DETENTEUR (pas de prise en charge), seul next_owner pointe vers le circuit court.
+    expect(
+      isCarcasseDone(
+        c({
+          current_owner_role: 'PREMIER_DETENTEUR' as Carcasse['current_owner_role'],
+          next_owner_role: 'COMMERCE_DE_DETAIL' as Carcasse['next_owner_role'],
+        })
+      )
+    ).toBe(true);
+  });
+
   it.each(TERMINAL_STATUSES)('true for terminal svi_carcasse_status %s', (status) => {
     expect(isCarcasseDone(c({ svi_carcasse_status: status }))).toBe(true);
   });

--- a/app-local-first-react-router/src/utils/is-carcasse-done.ts
+++ b/app-local-first-react-router/src/utils/is-carcasse-done.ts
@@ -2,6 +2,7 @@ import { Carcasse, CarcasseStatus, User } from '@prisma/client';
 import type { FeiWithIntermediaires } from '@api/src/types/fei';
 import updateCarcasseStatus from './get-carcasse-status';
 import { EntityWithUserRelation } from '@api/src/types/entity';
+import { isRoleCircuitCourt } from './circuit-court';
 
 // États terminaux d'une carcasse : elle ne progressera plus.
 // CONSIGNE (attente IPM2) et SANS_DECISION ne sont pas terminaux.
@@ -26,11 +27,16 @@ export function isCarcasseClosedBySvi(carcasse: Carcasse): boolean {
 
 export function isCarcasseDone(carcasse: Carcasse): boolean {
   if (carcasse.svi_closed_at || carcasse.svi_automatic_closed_at) return true;
-  // Circuit court / commerce de détail : clôturée par l'intermédiaire, sans passage SVI.
   if (carcasse.intermediaire_closed_at) return true;
   if (carcasse.intermediaire_carcasse_refus_intermediaire_id) return true;
   if (carcasse.intermediaire_carcasse_manquante) return true;
   if (carcasse.consommateur_final_usage_domestique) return true;
+  // Circuit court (commerce de détail, particulier…) : destinataire terminal, sans passage SVI
+  // ni prise en charge. La carcasse ne progressera plus dès qu'elle lui est transmise — c'est
+  // le même critère que celui qui clôture la fiche côté backend (notifyCircuitCourt).
+  if (isRoleCircuitCourt(carcasse.next_owner_role) || isRoleCircuitCourt(carcasse.current_owner_role)) {
+    return true;
+  }
   const status = carcasse.svi_carcasse_status ?? updateCarcasseStatus(carcasse);
   return TERMINAL_STATUSES.has(status);
 }


### PR DESCRIPTION
Une carcasse dont le destinataire est un rôle de circuit court (commerce de détail, particulier…) est un destinataire terminal : pas d'inspection ni de retransmission. Elle restait à tort « En cours de traitement ». Nouvel état `transmise-circuit-court` → libellé « Transmise » (vert).

Côté chasseur, l'en-tête de regroupement passe de « Vers » à « Envoyée à » pour lever l'ambiguïté (la fiche a déjà été transmise par mail).