### PR TITLE
fix: masquer le bloc prise en charge collecteur après transmission

### DIFF
--- a/app-local-first-react-router/src/routes/collecteur/collecteur-current-owner-confirm.tsx
+++ b/app-local-first-react-router/src/routes/collecteur/collecteur-current-owner-confirm.tsx
@@ -76,8 +76,9 @@ export default function CurrentOwnerConfirm() {
   if (transmissionMetadata.allCarcassesDone) {
     return null;
   }
-  // Multi-recipient: user already took charge of their assigned carcasses
-  if (myCarcasses.length === 0 && myAlreadyHandledCarcasses.length > 0) {
+  // Le collecteur a déjà pris en charge toutes les carcasses du groupe (il les contrôle/transporte
+  // déjà) : on ne réaffiche pas le bloc de prise en charge, même après transmission au prochain détenteur.
+  if (myCarcasses.length > 0 && myAlreadyHandledCarcasses.length === myCarcasses.length) {
     return null;
   }
 


### PR DESCRIPTION
Le bloc de prise en charge réapparaissait quand le collecteur revenait sur une fiche après avoir contrôlé, transporté et transmis les carcasses. Le garde "déjà pris en charge" était copié du composant chasseur où myCarcasses est filtré sur "je suis next_owner", alors qu'ici myCarcasses regroupe toutes les carcasses du dispatch et ne se vide jamais. On masque désormais le bloc dès que le collecteur possède toutes les carcasses du groupe.