### PR TITLE
feat: notifier l'expéditeur quand un destinataire renvoie la fiche

### DIFF
--- a/api-express/src/__tests__/carcasse-side-effects.test.ts
+++ b/api-express/src/__tests__/carcasse-side-effects.test.ts
@@ -1,9 +1,13 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { CarcasseStatus } from '@prisma/client';
+import { CarcasseStatus, FeiOwnerRole } from '@prisma/client';
 import prisma from '~/prisma';
 import sendNotificationToUser from '~/service/notifications';
 import { sendWebhook } from '~/utils/api';
-import { closeFeiAndNotifyChasseurOnSviCarcasseClose } from '~/utils/carcasse-side-effects';
+import { formatRenvoiExpediteurEmail } from '~/utils/formatCarcasseEmail';
+import {
+  closeFeiAndNotifyChasseurOnSviCarcasseClose,
+  notifyRenvoiExpediteur,
+} from '~/utils/carcasse-side-effects';
 
 vi.mock('~/service/notifications', () => ({
   default: vi.fn().mockResolvedValue(undefined),
@@ -12,6 +16,7 @@ vi.mock('~/utils/formatCarcasseEmail', () => ({
   formatManualValidationSviChasseurEmail: vi.fn().mockResolvedValue(['object', 'body']),
   formatCarcasseManquanteOrRefusChasseurEmail: vi.fn().mockResolvedValue(['object', 'body']),
   formatSaisieChasseurEmail: vi.fn().mockReturnValue(['object', 'body']),
+  formatRenvoiExpediteurEmail: vi.fn().mockReturnValue(['object', 'body']),
 }));
 vi.mock('~/utils/generate-certificats', () => ({ checkGenerateCertificat: vi.fn() }));
 vi.mock('~/utils/api', () => ({ sendWebhook: vi.fn().mockResolvedValue(undefined) }));
@@ -138,6 +143,110 @@ describe('closeFeiAndNotifyChasseurOnSviCarcasseClose — full close', () => {
 
     expect(sendNotificationToUser).toHaveBeenCalledOnce();
     expect(sendWebhook).toHaveBeenCalledOnce();
+  });
+});
+
+// Renvoi : le destinataire (ETG/collecteur, ici next_owner = ETG) vide le next_owner ; le current_owner
+// (l'expéditeur, ici le premier détenteur) reste inchangé.
+const expediteurUser = { id: 'pd-1', email: 'pd@example.org', notifications: [] as string[] };
+
+const makeRenvoiExisting = (overrides: any = {}) => ({
+  zacharie_carcasse_id: `${feiNumero}_BR-A`,
+  fei_numero: feiNumero,
+  current_owner_user_id: 'pd-1',
+  current_owner_role: FeiOwnerRole.PREMIER_DETENTEUR,
+  next_owner_role: FeiOwnerRole.ETG,
+  next_owner_entity_id: 'etg-entity-1',
+  next_owner_entity_name_cache: 'ETG du Loup',
+  next_owner_user_id: null,
+  next_owner_user_name_cache: null,
+  premier_detenteur_prochain_detenteur_id_cache: 'etg-entity-1',
+  ...overrides,
+});
+
+const makeRenvoiUpdated = (overrides: any = {}) =>
+  makeRenvoiExisting({
+    next_owner_role: null,
+    next_owner_entity_id: null,
+    next_owner_entity_name_cache: null,
+    next_owner_user_id: null,
+    next_owner_user_name_cache: null,
+    ...overrides,
+  });
+
+describe('notifyRenvoiExpediteur', () => {
+  test('notifies the expéditeur (current-owner) when a recipient returns the fiche', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(expediteurUser as any);
+    vi.mocked(prisma.fei.findUnique).mockResolvedValueOnce(makeFei() as any);
+
+    await notifyRenvoiExpediteur(makeRenvoiExisting() as any, makeRenvoiUpdated() as any);
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({ where: { id: 'pd-1' } });
+    expect(sendNotificationToUser).toHaveBeenCalledOnce();
+    const arg = vi.mocked(sendNotificationToUser).mock.calls[0][0] as any;
+    expect(arg.user).toBe(expediteurUser);
+    expect(arg.notificationLogAction).toBe(`FEI_RENVOYEE_${feiNumero}_etg-entity-1`);
+    // le formateur reçoit le rôle de l'expéditeur + le nom du destinataire qui renvoie
+    expect(formatRenvoiExpediteurEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ numero: feiNumero }),
+      FeiOwnerRole.PREMIER_DETENTEUR,
+      'ETG du Loup',
+      'etg-entity-1'
+    );
+  });
+
+  test('no-op on a prise en charge (current-owner changes to the recipient)', async () => {
+    const existing = makeRenvoiExisting();
+    const updated = makeRenvoiUpdated({
+      current_owner_user_id: 'etg-user-1',
+      current_owner_role: FeiOwnerRole.ETG,
+    });
+
+    await notifyRenvoiExpediteur(existing as any, updated as any);
+
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(sendNotificationToUser).not.toHaveBeenCalled();
+  });
+
+  test('no-op when the next_owner is still set (no renvoi happened)', async () => {
+    const existing = makeRenvoiExisting();
+    const updated = makeRenvoiExisting();
+
+    await notifyRenvoiExpediteur(existing as any, updated as any);
+
+    expect(sendNotificationToUser).not.toHaveBeenCalled();
+  });
+
+  test('uses one stable action key across the whole returned batch (dedups to a single notif)', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(expediteurUser as any);
+    vi.mocked(prisma.fei.findUnique).mockResolvedValue(makeFei() as any);
+
+    await notifyRenvoiExpediteur(
+      makeRenvoiExisting({ zacharie_carcasse_id: `${feiNumero}_BR-A` }) as any,
+      makeRenvoiUpdated({ zacharie_carcasse_id: `${feiNumero}_BR-A` }) as any
+    );
+    await notifyRenvoiExpediteur(
+      makeRenvoiExisting({ zacharie_carcasse_id: `${feiNumero}_BR-B` }) as any,
+      makeRenvoiUpdated({ zacharie_carcasse_id: `${feiNumero}_BR-B` }) as any
+    );
+
+    const actions = vi
+      .mocked(sendNotificationToUser)
+      .mock.calls.map((c) => (c[0] as any).notificationLogAction);
+    // clé identique pour les 2 carcasses → la dédup notificationLog n'enverra qu'une notif
+    expect(actions).toEqual([
+      `FEI_RENVOYEE_${feiNumero}_etg-entity-1`,
+      `FEI_RENVOYEE_${feiNumero}_etg-entity-1`,
+    ]);
+  });
+
+  test('no-op when the expéditeur user cannot be found', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null as any);
+
+    await notifyRenvoiExpediteur(makeRenvoiExisting() as any, makeRenvoiUpdated() as any);
+
+    expect(prisma.fei.findUnique).not.toHaveBeenCalled();
+    expect(sendNotificationToUser).not.toHaveBeenCalled();
   });
 });
 

--- a/api-express/src/utils/carcasse-side-effects.ts
+++ b/api-express/src/utils/carcasse-side-effects.ts
@@ -4,6 +4,7 @@ import sendNotificationToUser from '~/service/notifications';
 import {
   formatCarcasseManquanteOrRefusChasseurEmail,
   formatManualValidationSviChasseurEmail,
+  formatRenvoiExpediteurEmail,
   formatSaisieChasseurEmail,
 } from '~/utils/formatCarcasseEmail';
 import { checkGenerateCertificat } from '~/utils/generate-certificats';
@@ -94,6 +95,47 @@ export async function notifyRefusChasseur(existingCarcasse: Carcasse, updatedCar
   }
 }
 
+// Quand un destinataire (ETG ou collecteur) clique sur « Renvoyer à l'expéditeur », le next_owner
+// de ses carcasses est vidé alors que le current_owner reste inchangé (l'expéditeur). On détecte ce
+// cas — distinct d'une prise en charge, où le current_owner devient le destinataire — et on notifie
+// l'expéditeur. Le renvoi touche un lot de carcasses ; la dédup notificationLog sur une action par
+// (fiche, destinataire qui renvoie) garantit une seule notification.
+export async function notifyRenvoiExpediteur(existingCarcasse: Carcasse, updatedCarcasse: Carcasse) {
+  const isRenvoi =
+    !!existingCarcasse.next_owner_role &&
+    !updatedCarcasse.next_owner_role &&
+    !!updatedCarcasse.current_owner_user_id &&
+    existingCarcasse.current_owner_user_id === updatedCarcasse.current_owner_user_id &&
+    existingCarcasse.current_owner_role === updatedCarcasse.current_owner_role;
+  if (!isRenvoi) return;
+
+  const expediteur = await prisma.user.findUnique({
+    where: { id: updatedCarcasse.current_owner_user_id! },
+  });
+  if (!expediteur) return;
+
+  const fei = await prisma.fei.findUnique({ where: { numero: updatedCarcasse.fei_numero } });
+  if (!fei) return;
+
+  const renvoyeurName =
+    existingCarcasse.next_owner_entity_name_cache || existingCarcasse.next_owner_user_name_cache || null;
+  const action = `FEI_RENVOYEE_${updatedCarcasse.fei_numero}_${existingCarcasse.next_owner_entity_id ?? existingCarcasse.next_owner_user_id}`;
+
+  const [object, email] = formatRenvoiExpediteurEmail(
+    fei,
+    updatedCarcasse.current_owner_role!,
+    renvoyeurName,
+    updatedCarcasse.premier_detenteur_prochain_detenteur_id_cache
+  );
+  await sendNotificationToUser({
+    user: expediteur,
+    title: object,
+    body: email,
+    email,
+    notificationLogAction: action,
+  });
+}
+
 export async function checkCertificat(existingCarcasse: Carcasse, updatedCarcasse: Carcasse) {
   if (updatedCarcasse.svi_ipm1_date || updatedCarcasse.svi_ipm2_date) {
     await checkGenerateCertificat(existingCarcasse, updatedCarcasse);
@@ -172,6 +214,7 @@ export async function runCarcasseUpdateSideEffects(existingCarcasse: Carcasse, u
   await notifySaisieChasseur(existingCarcasse, updatedCarcasse);
   await notifyManquanteChasseur(existingCarcasse, updatedCarcasse);
   await notifyRefusChasseur(existingCarcasse, updatedCarcasse);
+  await notifyRenvoiExpediteur(existingCarcasse, updatedCarcasse);
   await closeFeiAndNotifyChasseurOnSviCarcasseClose(existingCarcasse, updatedCarcasse);
   await checkCertificat(existingCarcasse, updatedCarcasse);
 }

--- a/api-express/src/utils/formatCarcasseEmail.ts
+++ b/api-express/src/utils/formatCarcasseEmail.ts
@@ -176,7 +176,7 @@ export function formatRenvoiExpediteurEmail(
 
   const email = [
     `Bonjour,`,
-    `${renvoyeur} a renvoyé la fiche ${fei.numero} : les carcasses concernées sont de nouveau à votre charge.`,
+    `${renvoyeur} a renvoyé la fiche ${fei.numero} : vous devez choisir un autre destinataire pour cette fiche.`,
     `Pour consulter la fiche, rendez-vous sur Zacharie : ${url}`,
     `Ce message a été généré automatiquement par l’application Zacharie. Si vous avez des questions sur ce renvoi, merci de contacter l’établissement qui vous a renvoyé la fiche.`,
   ];

--- a/api-express/src/utils/formatCarcasseEmail.ts
+++ b/api-express/src/utils/formatCarcasseEmail.ts
@@ -1,4 +1,4 @@
-import { Carcasse, CarcasseStatus, CarcasseType, Fei, IPM2Decision } from '@prisma/client';
+import { Carcasse, CarcasseStatus, CarcasseType, Fei, FeiOwnerRole, IPM2Decision } from '@prisma/client';
 import { getCarcasseStatusLabelForEmail } from './get-carcasse-status';
 import lesions from '../assets/lesions.json';
 import prisma from '~/prisma';
@@ -158,6 +158,30 @@ export async function formatCarcasseManquanteOrRefusChasseurEmail(
     `Ce message a été généré automatiquement par l’application Zacharie. Si vous avez des questions sur ce constat, merci de contacter l’organisme qui a constaté ce manque.`,
   ];
   const object = `${carcasseLabel} de ${carcasse.espece.toLowerCase()} n°${no} est ${refusLabel}.`;
+  return [object, email.filter(Boolean).join('\n\n')];
+}
+
+export function formatRenvoiExpediteurEmail(
+  fei: Fei,
+  expediteurRole: FeiOwnerRole,
+  renvoyeurName: string | null,
+  premierDetenteurProchainDetenteurIdCache: string | null
+): [string, string] {
+  const url =
+    expediteurRole === FeiOwnerRole.COLLECTEUR_PRO
+      ? `https://zacharie.beta.gouv.fr/app/collecteur/fei/${fei.numero}/${premierDetenteurProchainDetenteurIdCache}`
+      : `https://zacharie.beta.gouv.fr/app/chasseur/fei/${fei.numero}`;
+
+  const renvoyeur = renvoyeurName ?? 'Le destinataire';
+
+  const email = [
+    `Bonjour,`,
+    `${renvoyeur} a renvoyé la fiche ${fei.numero} : les carcasses concernées sont de nouveau à votre charge.`,
+    `Pour consulter la fiche, rendez-vous sur Zacharie : ${url}`,
+    `Ce message a été généré automatiquement par l’application Zacharie. Si vous avez des questions sur ce renvoi, merci de contacter l’établissement qui vous a renvoyé la fiche.`,
+  ];
+
+  const object = `La fiche ${fei.numero} vous a été renvoyée.`;
   return [object, email.filter(Boolean).join('\n\n')];
 }
 

--- a/doc/emails.md
+++ b/doc/emails.md
@@ -40,20 +40,21 @@ Tout passe par **Brevo** — pas de SMTP / nodemailer / autre.
 
 Toutes via `sendNotificationToUser`. Dédup via `NotificationLog`. Déclenchées depuis les side-effects de sync (`controllers/sync.ts`).
 
-| Déclencheur                          | Destinataire                | Objet                                                                                             | Fichier                                     |
-| ------------------------------------ | --------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| FEI transmise au SVI                 | users SVI de l'entité       | `L'établissement {nom} vous a transmis une fiche comprenant {n} carcasses (ou lots) à inspecter:` | `fei-side-effects.ts:137`                   |
-| FEI attribuée à entité circuit-court | users de l'entité (+ PDF)   | `{prenom} {nom} vous a attribué une fiche d'examen initial du gibier sauvage n° {numero}`         | `fei-side-effects.ts:228`                   |
-| FEI attribuée à un user              | le next-owner               | `{prenom} {nom} vous a attribué la fiche {numero}`                                                | `fei-side-effects.ts:305`                   |
-| FEI désattribuée (correction)        | l'ex-next-owner             | `La fiche n° {numero} ne vous est plus attribuée`                                                 | `fei-side-effects.ts:327`                   |
-| FEI attribuée à une entité           | users de l'entité           | `{prenom} {nom} vous a attribué la fiche {numero}`                                                | `fei-side-effects.ts:390`                   |
-| Saisie SVI (partielle / totale)      | examinateur + 1er détenteur | `{saisie} {de la carcasse/du lot} de {espèce} n°{bracelet}.`                                      | `carcasse-side-effects.ts:31,40`            |
-| Carcasse manquante                   | examinateur + 1er détenteur | `{La carcasse/Le lot} de {espèce} n°{no} est manquante.`                                          | `carcasse-side-effects.ts:31,40`            |
-| Carcasse refusée                     | examinateur + 1er détenteur | `{La carcasse/Le lot} de {espèce} n°{no} est refusée.`                                            | `carcasse-side-effects.ts:31,40`            |
-| FEI clôturée (dernière carcasse)     | examinateur + 1er détenteur | `La fiche {numero} est clôturée.`                                                                 | `carcasse-side-effects.ts:161,166`          |
-| Nouvel user dans une entité          | admins de l'entité          | `Un nouvel utilisateur s'est inscrit sur Zacharie au sein de votre entité`                        | `user-entity.ts:217`                        |
-| Demande de modif carcasse créée      | examinateur de la FEI       | `Chasse du {date}` / `Demande de modification`                                                    | `sync-carcasse-modification-request.ts:203` |
-| Demande de modif traitée             | le demandeur                | `Carcasse numéro {bracelet}` / `Demande traitée`                                                  | `sync-carcasse-modification-request.ts:239` |
+| Déclencheur                          | Destinataire                 | Objet                                                                                             | Fichier                                           |
+| ------------------------------------ | ---------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| FEI transmise au SVI                 | users SVI de l'entité        | `L'établissement {nom} vous a transmis une fiche comprenant {n} carcasses (ou lots) à inspecter:` | `fei-side-effects.ts:137`                         |
+| FEI attribuée à entité circuit-court | users de l'entité (+ PDF)    | `{prenom} {nom} vous a attribué une fiche d'examen initial du gibier sauvage n° {numero}`         | `fei-side-effects.ts:228`                         |
+| FEI attribuée à un user              | le next-owner                | `{prenom} {nom} vous a attribué la fiche {numero}`                                                | `fei-side-effects.ts:305`                         |
+| FEI désattribuée (correction)        | l'ex-next-owner              | `La fiche n° {numero} ne vous est plus attribuée`                                                 | `fei-side-effects.ts:327`                         |
+| FEI attribuée à une entité           | users de l'entité            | `{prenom} {nom} vous a attribué la fiche {numero}`                                                | `fei-side-effects.ts:390`                         |
+| Saisie SVI (partielle / totale)      | examinateur + 1er détenteur  | `{saisie} {de la carcasse/du lot} de {espèce} n°{bracelet}.`                                      | `carcasse-side-effects.ts:31,40`                  |
+| Carcasse manquante                   | examinateur + 1er détenteur  | `{La carcasse/Le lot} de {espèce} n°{no} est manquante.`                                          | `carcasse-side-effects.ts:31,40`                  |
+| Carcasse refusée                     | examinateur + 1er détenteur  | `{La carcasse/Le lot} de {espèce} n°{no} est refusée.`                                            | `carcasse-side-effects.ts:31,40`                  |
+| FEI clôturée (dernière carcasse)     | examinateur + 1er détenteur  | `La fiche {numero} est clôturée.`                                                                 | `carcasse-side-effects.ts:161,166`                |
+| Fiche renvoyée à l'expéditeur        | l'expéditeur (current-owner) | `La fiche {numero} vous a été renvoyée.`                                                          | `carcasse-side-effects.ts:notifyRenvoiExpediteur` |
+| Nouvel user dans une entité          | admins de l'entité           | `Un nouvel utilisateur s'est inscrit sur Zacharie au sein de votre entité`                        | `user-entity.ts:217`                              |
+| Demande de modif carcasse créée      | examinateur de la FEI        | `Chasse du {date}` / `Demande de modification`                                                    | `sync-carcasse-modification-request.ts:203`       |
+| Demande de modif traitée             | le demandeur                 | `Carcasse numéro {bracelet}` / `Demande traitée`                                                  | `sync-carcasse-modification-request.ts:239`       |
 
 ## 4. Cron (`npm run start-cronjobs` — prod uniquement, `cronjobs/index.ts`)
 


### PR DESCRIPTION
Quand un ETG (ou collecteur) clique sur « Renvoyer à l'expéditeur », le next_owner des carcasses est vidé sans notification. Ajoute un side-effect notifyRenvoiExpediteur qui détecte ce cas (next_owner vidé, current_owner inchangé) et notifie l'expéditeur. Dédup par (fiche, destinataire) pour une seule notif par lot renvoyé.