### PR TITLE
fix: demande de modif de marquage indicative, ne bloque plus le SVI

### DIFF
--- a/app-local-first-react-router/src/components/CarcasseModificationRequest.tsx
+++ b/app-local-first-react-router/src/components/CarcasseModificationRequest.tsx
@@ -37,15 +37,19 @@ export function PendingModificationBanner({ carcasse }: { carcasse: Carcasse }) 
 
   if (!pending) return null;
 
-  const title =
-    pending.type === CarcasseModificationRequestType.BRACELET_RENAME
-      ? `Demande de modification du numéro de marquage en cours`
-      : `Carcasse ajoutée, approbation de mise sur le marché en attente`;
+  const isRename = pending.type === CarcasseModificationRequestType.BRACELET_RENAME;
 
-  const detail =
-    pending.type === CarcasseModificationRequestType.BRACELET_RENAME
-      ? `Le numéro physique semble être « ${pending.numero_bracelet_after} » au lieu de « ${pending.numero_bracelet_before} ». L'examinateur initial doit approuver ou refuser ce changement.`
-      : `Cette carcasse n'est pas encore validée par l'examinateur initial et ne sera pas inspectée par le SVI tant que l'approbation de mise sur le marché n'est pas faite.`;
+  // La demande est purement indicative : elle ne bloque ni la transmission ni l'inspection SVI.
+  // On garde donc une sévérité douce (info pour le renommage de marquage).
+  const severity = isRename ? 'info' : 'warning';
+
+  const title = isRename
+    ? `Modification du numéro de marquage`
+    : `Carcasse ajoutée, approbation de mise sur le marché en attente`;
+
+  const detail = isRename
+    ? `Le numéro physique relevé serait « ${pending.numero_bracelet_after} » au lieu de « ${pending.numero_bracelet_before} ». En attente de confirmation par l'examinateur initial.`
+    : `Cette carcasse a été ajoutée par un intermédiaire et n'est pas encore validée par l'examinateur initial.`;
 
   const requester = [requestedByUser?.prenom, requestedByUser?.nom_de_famille].filter(Boolean).join(' ');
   const entityName = requestedByEntity?.nom_d_usage ?? '';
@@ -71,7 +75,7 @@ export function PendingModificationBanner({ carcasse }: { carcasse: Carcasse }) 
 
   return (
     <Alert
-      severity="warning"
+      severity={severity}
       title={title}
       description={
         <>
@@ -211,8 +215,8 @@ export function RequestBraceletRenameButton({
           />
           {error && <p className="text-action-high-red-marianne mt-1 text-sm">{error}</p>}
           <p className="mt-3 text-sm opacity-80">
-            La demande sera envoyée à l'examinateur initial pour approbation. En attendant sa validation, la
-            carcasse peut être transmise au SVI mais celui-ci ne pourra pas la contrôler.
+            La demande sera envoyée à l'examinateur initial pour confirmation. En attendant, la carcasse
+            continue son parcours normalement et peut être inspectée par le SVI.
           </p>
           <div className="mt-4 flex gap-2">
             <Button

--- a/app-local-first-react-router/src/routes/svi/svi-carcasse-svi-inspection.tsx
+++ b/app-local-first-react-router/src/routes/svi/svi-carcasse-svi-inspection.tsx
@@ -21,7 +21,6 @@ import {
   HistoriqueDesModifications,
 } from '@app/components/CarcasseModificationRequest';
 import { loadData, useLoaderEffect } from '@app/utils/load-data';
-import { getPendingModifRequest } from '@app/utils/modif-requests';
 import { getTransmissionLinkFromCarcasse } from '@app/utils/get-transmission-id';
 import TrichineSection from '@app/components/TrichineSection';
 import { TRICHINE_FEATURE_ENABLED } from '@app/utils/trichine';
@@ -89,14 +88,10 @@ function SviInspectionCarcasse() {
   const allModifRequests = useZustandStore(
     (state) => state.modifRequestsByCarcasseId[carcasse.zacharie_carcasse_id]
   );
-  const pendingModifRequest = getPendingModifRequest(allModifRequests);
 
   const canEdit = useMemo(() => {
-    // SVI ne peut pas inspecter une carcasse dont l'identité (numéro de marquage) ou la signature de
-    // l'examen initial sont en attente d'approbation par l'examinateur initial. Blocage dur.
-    if (pendingModifRequest) {
-      return false;
-    }
+    // Une demande de modification (numéro de marquage, carcasse ajoutée) est purement indicative :
+    // elle ne bloque plus l'inspection du SVI. On l'affiche via PendingModificationBanner.
     if (isSviWorkingFor) {
       return true;
     }
@@ -107,7 +102,7 @@ function SviInspectionCarcasse() {
       return false;
     }
     return true;
-  }, [carcasse, user, isSviWorkingFor, pendingModifRequest]);
+  }, [carcasse, user, isSviWorkingFor]);
 
   const initIMP1Open = useRef(!carcasse.svi_ipm1_decision);
   const initIMP2Open = useRef(
@@ -200,20 +195,13 @@ function SviInspectionCarcasse() {
               viewRole="svi"
             />
           )}
-          {(canEdit || pendingModifRequest) && (
+          {canEdit && (
             <>
               <Section
                 open={initIMP1Open.current}
                 title={`Inspection Post-Mortem 1 (IPM1)${carcasse.svi_ipm1_date ? ` - ${dayjs(carcasse.svi_ipm1_date).format('DD-MM-YYYY')}` : ''}`}
               >
-                {pendingModifRequest ? (
-                  <p className="m-0">
-                    Tant que l'examinateur initial n'a pas fait approuvé la mise sur le marché, il est
-                    impossible de réaliser les inspections post-mortem.
-                  </p>
-                ) : (
-                  <CarcasseIPM1 canEdit={canEdit} />
-                )}
+                <CarcasseIPM1 canEdit={canEdit} />
               </Section>
               <Section
                 open={initIMP2Open.current}
@@ -224,14 +212,7 @@ function SviInspectionCarcasse() {
                 }
               >
                 <div>
-                  {pendingModifRequest ? (
-                    <p className="m-0">
-                      Tant que l'examinateur initial n'a pas fait approuvé la mise sur le marché, il est
-                      impossible de réaliser les inspections post-mortem.
-                    </p>
-                  ) : (
-                    <CarcasseIPM2 canEdit={canEdit && carcasse.svi_ipm1_decision !== IPM1Decision.ACCEPTE} />
-                  )}
+                  <CarcasseIPM2 canEdit={canEdit && carcasse.svi_ipm1_decision !== IPM1Decision.ACCEPTE} />
                 </div>
               </Section>
             </>

--- a/e2e/tests/etg/62-modif-request-rename-approved.spec.ts
+++ b/e2e/tests/etg/62-modif-request-rename-approved.spec.ts
@@ -36,7 +36,7 @@ test('Rename marquage : ETG signale → examinateur approuve → maj visible cô
 
   // The outer refus modal closes after submission. The PendingModificationBanner shows up under the
   // card to confirm sync round-trip.
-  await expect(page.getByText('Demande de modification du numéro de marquage en cours').first()).toBeVisible({
+  await expect(page.getByText('Modification du numéro de marquage').first()).toBeVisible({
     timeout: 10000,
   });
 
@@ -68,6 +68,6 @@ test('Rename marquage : ETG signale → examinateur approuve → maj visible cô
   });
   await expect(page.getByRole('button', { name: 'Daim N° MM-001-001 Mise à' })).toHaveCount(0);
   // The pending banner is gone, the card description gained a "1 modification" line.
-  await expect(page.getByText('Demande de modification du numéro de marquage en cours')).toHaveCount(0);
+  await expect(page.getByText('Modification du numéro de marquage')).toHaveCount(0);
   await expect(page.getByText('1 modification').first()).toBeVisible();
 });

--- a/e2e/tests/etg/63-modif-request-rename-rejected.spec.ts
+++ b/e2e/tests/etg/63-modif-request-rename-rejected.spec.ts
@@ -25,7 +25,7 @@ test('Rename rejected : examinateur refuse → ETG voit warning sur la carcasse'
   await page.getByRole('button', { name: 'Signaler un numéro de marquage incorrect' }).click();
   await page.getByLabel('Numéro de marquage correct').fill('MM-001-Z99');
   await page.getByRole('button', { name: 'Envoyer la demande' }).click();
-  await expect(page.getByText('Demande de modification du numéro de marquage en cours').first()).toBeVisible({
+  await expect(page.getByText('Modification du numéro de marquage').first()).toBeVisible({
     timeout: 10000,
   });
 
@@ -49,7 +49,7 @@ test('Rename rejected : examinateur refuse → ETG voit warning sur la carcasse'
   await expect(page.getByRole('button', { name: 'Daim N° MM-001-002 Mise à' })).toBeVisible({
     timeout: 10000,
   });
-  await expect(page.getByText('Demande de modification du numéro de marquage en cours')).toHaveCount(0);
+  await expect(page.getByText('Modification du numéro de marquage')).toHaveCount(0);
   // 1 modification line is visible somewhere on the card.
   await expect(page.getByText('1 modification').first()).toBeVisible();
 

--- a/e2e/tests/etg/65-modif-request-cancel.spec.ts
+++ b/e2e/tests/etg/65-modif-request-cancel.spec.ts
@@ -26,7 +26,7 @@ test('Annulation : le demandeur peut annuler sa propre demande pendante', async 
   await page.getByRole('button', { name: 'Envoyer la demande' }).click();
 
   // Pending banner attached under the card.
-  const pendingBanner = page.getByText('Demande de modification du numéro de marquage en cours').first();
+  const pendingBanner = page.getByText('Modification du numéro de marquage').first();
   await expect(pendingBanner).toBeVisible({ timeout: 10000 });
 
   // Confirm dialog → accept.
@@ -39,7 +39,7 @@ test('Annulation : le demandeur peut annuler sa propre demande pendante', async 
   await page.getByRole('button', { name: 'Annuler ma demande' }).click();
 
   // Banner gone.
-  await expect(page.getByText('Demande de modification du numéro de marquage en cours')).toHaveCount(0, {
+  await expect(page.getByText('Modification du numéro de marquage')).toHaveCount(0, {
     timeout: 10000,
   });
 

--- a/e2e/tests/etg/66-modif-request-new-carcasse-after-svi-transmit.spec.ts
+++ b/e2e/tests/etg/66-modif-request-new-carcasse-after-svi-transmit.spec.ts
@@ -51,20 +51,19 @@ test('Ajout carcasse manquante pré-transmission SVI : visible par SVI, pas de b
     page.getByText('Carcasse ajoutée, approbation de mise sur le marché en attente').first()
   ).toBeVisible();
 
-  // Step 3: Opening the carcasse inspection page shows the IPM section with the explanatory
-  // message — not the IPM form — because the examinateur has not signed yet.
+  // Step 3: Opening the carcasse inspection page shows the IPM form — the pending "carcasse ajoutée"
+  // request is purely informative and no longer blocks the SVI inspection.
   await page
     .getByRole('button', { name: new RegExp(`Cerf élaphe.*${newBracelet}`) })
     .first()
     .click();
   await expect(page).toHaveURL(/\/app\/svi\/carcasse-svi\//);
+  await expect(page.getByText("Carcasse présentée à l'inspection").first()).toBeVisible();
   await expect(
-    page
-      .getByText(
-        "Tant que l'examinateur initial n'a pas fait approuvé la mise sur le marché, il est impossible de réaliser les inspections post-mortem."
-      )
-      .first()
-  ).toBeVisible();
+    page.getByText(
+      "Tant que l'examinateur initial n'a pas fait approuvé la mise sur le marché, il est impossible de réaliser les inspections post-mortem."
+    )
+  ).toHaveCount(0);
 
   // Step 4: Examinateur signs the approval.
   await logoutAndConnect(page, 'examinateur@example.fr');

--- a/e2e/tests/examinateur/25-modif-request-dashboard.spec.ts
+++ b/e2e/tests/examinateur/25-modif-request-dashboard.spec.ts
@@ -27,7 +27,7 @@ test('Examinateur dashboard alert modal + nav badge + grouping', async ({ page }
   await page.getByRole('button', { name: 'Signaler un numéro de marquage incorrect' }).click();
   await page.getByLabel('Numéro de marquage correct').fill('MM-001-FIX');
   await page.getByRole('button', { name: 'Envoyer la demande' }).click();
-  await expect(page.getByText('Demande de modification du numéro de marquage en cours').first()).toBeVisible({
+  await expect(page.getByText('Modification du numéro de marquage').first()).toBeVisible({
     timeout: 10000,
   });
 

--- a/e2e/tests/svi/79-modif-request-does-not-block-svi-inspection.spec.ts
+++ b/e2e/tests/svi/79-modif-request-does-not-block-svi-inspection.spec.ts
@@ -9,14 +9,13 @@ test.beforeEach(async () => {
 
 test.use({ launchOptions: { slowMo: 100 } });
 
-// Scenario 79 — A pending modif request blocks SVI inspection (rule Q1 = c, hard block).
-// We need to inject a pending request from another role first. We do that by simulating ETG
-// signaling an incorrect marquage for one of the carcasses already assigned to SVI in the SVI seed.
-// Then the SVI logs in and sees:
-//   - PendingModificationBanner on the carcasse in the list
-//   - On the carcasse inspection page, IPM1/IPM2 sections shown but with a message explaining the
-//     inspections cannot be carried out yet (the IPM forms themselves are not rendered).
-test('SVI canEdit blocked when a pending modif exists on the carcasse', async ({ page }) => {
+// Scenario 79 — A pending modif request is purely informative and does NOT block SVI inspection.
+// We inject a pending request from another role first, by simulating ETG signaling an incorrect
+// marquage for one of the carcasses already assigned to SVI in the SVI seed. Then the SVI logs in
+// and sees:
+//   - the (soft, info-level) "Modification du numéro de marquage" banner on the carcasse
+//   - on the inspection page, the IPM1/IPM2 forms ARE rendered (no blocking message)
+test('SVI can still inspect when a pending modif exists on the carcasse', async ({ page }) => {
   const feiId = 'ZACH-20250707-QZ6E0-235243';
 
   // Step 1: ETG-1 (still has CarcasseIntermediaire row from the SVI seed) signals a wrong marquage.
@@ -28,33 +27,31 @@ test('SVI canEdit blocked when a pending modif exists on the carcasse', async ({
   await page.getByRole('button', { name: 'Signaler un numéro de marquage incorrect' }).click();
   await page.getByLabel('Numéro de marquage correct').fill('MM-001-NEW');
   await page.getByRole('button', { name: 'Envoyer la demande' }).click();
-  await expect(page.getByText('Demande de modification du numéro de marquage en cours').first()).toBeVisible({
+  await expect(page.getByText('Modification du numéro de marquage').first()).toBeVisible({
     timeout: 10000,
   });
 
-  // Step 2: SVI logs in. The pending banner is attached to the carcasse on the inspection list.
+  // Step 2: SVI logs in. The informative banner is attached to the carcasse on the inspection list.
   await logoutAndConnect(page, 'svi@example.fr');
   await page.getByRole('link', { name: feiId }).click();
-  await expect(page.getByText('Demande de modification du numéro de marquage en cours').first()).toBeVisible({
+  await expect(page.getByText('Modification du numéro de marquage').first()).toBeVisible({
     timeout: 10000,
   });
 
-  // Step 3: opening the carcasse inspection page — IPM1/IPM2 section headers ARE rendered, but
-  // the inspection forms are replaced by an explanatory message.
+  // Step 3: opening the carcasse inspection page — the IPM1/IPM2 forms are rendered and usable.
+  // The old blocking message must NOT appear.
   await page
     .getByRole('button', { name: /Daim.*MM-001-001/ })
     .first()
     .click();
   await expect(page).toHaveURL(/\/app\/svi\/carcasse-svi\//);
   await expect(page.getByText('Inspection Post-Mortem 1 (IPM1)').first()).toBeVisible();
-  await expect(page.getByText('Inspection Post-Mortem 2 (IPM2)').first()).toBeVisible();
+  await expect(page.getByText("Carcasse présentée à l'inspection").first()).toBeVisible();
   await expect(
     page.getByText(
       "Tant que l'examinateur initial n'a pas fait approuvé la mise sur le marché, il est impossible de réaliser les inspections post-mortem."
     )
-  ).toHaveCount(2);
-  // The pending banner is shown on the inspection detail page too.
-  await expect(
-    page.getByText('Demande de modification du numéro de marquage en cours').first()
-  ).toBeVisible();
+  ).toHaveCount(0);
+  // The informative banner is still shown on the inspection detail page.
+  await expect(page.getByText('Modification du numéro de marquage').first()).toBeVisible();
 });


### PR DESCRIPTION
Une demande de modification (numéro de marquage, carcasse ajoutée) devient purement indicative : elle n'empêche plus le SVI de réaliser l'IPM1/IPM2. L'alerte SVI passe en info avec un intitulé plus doux « Modification du numéro de marquage » au lieu de l'alerte de blocage précédente.