### PR TITLE
fix: rendre visibles les carcasses refusées aux détenteurs suivants

### DIFF
--- a/api-express/src/__tests__/carcasse-refusees-route.test.ts
+++ b/api-express/src/__tests__/carcasse-refusees-route.test.ts
@@ -1,0 +1,224 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import carcasseRouter from '~/controllers/carcasse';
+import prisma from '~/prisma';
+import { EntityRelationStatus, EntityRelationType, UserRoles } from '@prisma/client';
+
+// GET /carcasse/refusees/:fei_numero — carcasses d'une fiche HORS du périmètre de synchro delta
+// (refusées/manquantes/orphelines). Une carcasse refusée « sort du circuit » : ses next/current_owner
+// ne suivent plus la transmission et son updated_at ne rebouge pas → le pull delta /carcasse ne la
+// renvoie jamais aux détenteurs suivants ni au SVI. Cette route la fournit à la demande, par fiche.
+//
+// Contrat épinglé ici :
+//  - l'autorisation reste au niveau carcasse : count des carcasses de la fiche DANS le périmètre
+//    normal de l'utilisateur (getCarcasseAccessWhere) ; 0 → 403.
+//  - la donnée renvoyée est le complément : { fei_numero, NOT: accessWhere }.
+
+const etgUser = {
+  id: 'user-etg',
+  roles: [UserRoles.ETG],
+  activated: true,
+  isZacharieAdmin: false,
+};
+
+const sviUser = {
+  id: 'user-svi',
+  roles: [UserRoles.SVI],
+  activated: true,
+  isZacharieAdmin: false,
+};
+
+const collecteurUser = {
+  id: 'user-coll',
+  roles: [UserRoles.COLLECTEUR_PRO],
+  activated: true,
+  isZacharieAdmin: false,
+};
+
+const unknownRoleUser = {
+  id: 'user-unknown',
+  roles: [] as UserRoles[],
+  activated: true,
+  isZacharieAdmin: false,
+};
+
+const inactiveEtg = { ...etgUser, activated: false };
+
+const app = express();
+app.use(express.json());
+app.use('/carcasse', carcasseRouter);
+
+const FEI = 'ZACH-2026-0001';
+const ENTITY_IDS = ['entity-1', 'entity-2'];
+
+// vitest.setup.ts ne fournit ni count ni carcasseIntermediaire.findMany — ajoutés pour ce suite.
+(prisma.carcasse as any).count = vi.fn().mockResolvedValue(0);
+(prisma.carcasseIntermediaire as any).findMany = vi.fn().mockResolvedValue([]);
+
+const etgAccessOR = [
+  { CarcasseIntermediaire: { some: { intermediaire_entity_id: { in: ENTITY_IDS } } } },
+  { next_owner_entity_id: { in: ENTITY_IDS } },
+  { current_owner_entity_id: { in: ENTITY_IDS } },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(prisma.carcasse.findMany).mockResolvedValue([]);
+  (prisma.carcasse as any).count.mockResolvedValue(0);
+  (prisma.carcasseIntermediaire as any).findMany.mockResolvedValue([]);
+  vi.mocked(prisma.entity.findMany).mockResolvedValue([]);
+  vi.mocked(prisma.entityAndUserRelations.findMany).mockResolvedValue([
+    { entity_id: 'entity-1' } as any,
+    { entity_id: 'entity-2' } as any,
+  ]);
+});
+
+describe('Auth / activation', () => {
+  test('unauthenticated → 401', async () => {
+    const res = await request(app).get(`/carcasse/refusees/${FEI}`);
+    expect(res.status).toBe(401);
+  });
+
+  test('non-activated user → 400, no DB query', async () => {
+    const res = await request(app)
+      .get(`/carcasse/refusees/${FEI}`)
+      .set('x-test-user', JSON.stringify(inactiveEtg));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Le compte n'est pas activé");
+    expect(prisma.carcasse.count).not.toHaveBeenCalled();
+    expect(prisma.carcasse.findMany).not.toHaveBeenCalled();
+  });
+
+  test('unknown role → 403, no carcasse query', async () => {
+    const res = await request(app)
+      .get(`/carcasse/refusees/${FEI}`)
+      .set('x-test-user', JSON.stringify(unknownRoleUser));
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Vous n'avez pas les permissions.");
+    expect(prisma.carcasse.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('Autorisation par accès à la fiche', () => {
+  test('aucune carcasse de la fiche dans le périmètre → 403, pas de fetch des refusées', async () => {
+    (prisma.carcasse as any).count.mockResolvedValue(0);
+
+    const res = await request(app)
+      .get(`/carcasse/refusees/${FEI}`)
+      .set('x-test-user', JSON.stringify(etgUser));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Vous n'avez pas accès à cette fiche.");
+    // le count d'autorisation est scopé fiche + périmètre normal de l'utilisateur
+    expect(prisma.carcasse.count).toHaveBeenCalledWith({
+      where: { fei_numero: FEI, OR: etgAccessOR },
+    });
+    // on ne va PAS chercher les carcasses hors périmètre si l'accès est refusé
+    expect(prisma.carcasse.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('ETG — récupération des carcasses refusées de la fiche', () => {
+  test('accès OK → 200, findMany scopé { fei_numero, NOT: accessWhere }', async () => {
+    (prisma.carcasse as any).count.mockResolvedValue(2); // l'ETG a bien des carcasses de la fiche
+    vi.mocked(prisma.carcasse.findMany).mockResolvedValue([
+      {
+        zacharie_carcasse_id: `${FEI}_001`,
+        fei_numero: FEI,
+        svi_carcasse_status: 'REFUS_ETG_COLLECTEUR',
+        current_owner_entity_id: 'entity-amont',
+        intermediaire_carcasse_refus_intermediaire_id: 'inter-1',
+      } as any,
+    ]);
+    (prisma.carcasseIntermediaire as any).findMany.mockResolvedValue([
+      { zacharie_carcasse_id: `${FEI}_001`, intermediaire_entity_id: 'entity-amont' } as any,
+    ]);
+    vi.mocked(prisma.entity.findMany).mockResolvedValue([
+      { id: 'entity-amont', nom_d_usage: 'ETG Amont' } as any,
+    ]);
+
+    const res = await request(app)
+      .get(`/carcasse/refusees/${FEI}`)
+      .set('x-test-user', JSON.stringify(etgUser));
+
+    expect(res.status).toBe(200);
+
+    // Le complément hors périmètre : toutes les carcasses de la fiche que le delta ne donne pas.
+    expect(prisma.carcasse.findMany).toHaveBeenCalledWith({
+      where: { fei_numero: FEI, NOT: { OR: etgAccessOR } },
+    });
+
+    // Les CarcasseIntermediaire (record de refus, pour le motif) sont récupérées pour ces carcasses.
+    expect(prisma.carcasseIntermediaire.findMany).toHaveBeenCalledWith({
+      where: { zacharie_carcasse_id: { in: [`${FEI}_001`] } },
+    });
+
+    expect(res.body.ok).toBe(true);
+    expect(res.body.data.carcasses).toHaveLength(1);
+    expect(res.body.data.carcasses[0].zacharie_carcasse_id).toBe(`${FEI}_001`);
+    expect(res.body.data.carcassesIntermediaires).toHaveLength(1);
+    expect(res.body.data.entities).toHaveLength(1);
+  });
+
+  test('COLLECTEUR_PRO utilise le même périmètre que l’ETG', async () => {
+    (prisma.carcasse as any).count.mockResolvedValue(1);
+
+    const res = await request(app)
+      .get(`/carcasse/refusees/${FEI}`)
+      .set('x-test-user', JSON.stringify(collecteurUser));
+
+    expect(res.status).toBe(200);
+    expect(prisma.carcasse.count).toHaveBeenCalledWith({
+      where: { fei_numero: FEI, OR: etgAccessOR },
+    });
+    expect(prisma.carcasse.findMany).toHaveBeenCalledWith({
+      where: { fei_numero: FEI, NOT: { OR: etgAccessOR } },
+    });
+  });
+});
+
+describe('SVI — voit les carcasses refusées en amont (champ de contrôle)', () => {
+  const sviAccessWhere = {
+    svi_assigned_at: { not: null },
+    OR: [{ svi_entity_id: { in: ENTITY_IDS } }, { next_owner_entity_id: { in: ENTITY_IDS } }],
+  };
+
+  test('accès OK → renvoie les refusées (sans svi_assigned_at) via NOT accessWhere', async () => {
+    (prisma.carcasse as any).count.mockResolvedValue(3); // fiche bien arrivée au SVI
+    vi.mocked(prisma.carcasse.findMany).mockResolvedValue([
+      {
+        zacharie_carcasse_id: `${FEI}_009`,
+        fei_numero: FEI,
+        svi_carcasse_status: 'REFUS_ETG_COLLECTEUR',
+        svi_assigned_at: null, // refusée en amont → jamais assignée au SVI
+      } as any,
+    ]);
+
+    const res = await request(app)
+      .get(`/carcasse/refusees/${FEI}`)
+      .set('x-test-user', JSON.stringify(sviUser));
+
+    expect(res.status).toBe(200);
+    // autorisation : au moins une carcasse de la fiche est bien dans le périmètre SVI
+    expect(prisma.carcasse.count).toHaveBeenCalledWith({
+      where: { fei_numero: FEI, ...sviAccessWhere },
+    });
+    // complément : les carcasses de la fiche hors périmètre SVI (svi_assigned_at null → refusées)
+    expect(prisma.carcasse.findMany).toHaveBeenCalledWith({
+      where: { fei_numero: FEI, NOT: sviAccessWhere },
+    });
+    expect(res.body.data.carcasses[0].svi_assigned_at).toBeNull();
+  });
+
+  test('fiche jamais arrivée au SVI → 403', async () => {
+    (prisma.carcasse as any).count.mockResolvedValue(0);
+
+    const res = await request(app)
+      .get(`/carcasse/refusees/${FEI}`)
+      .set('x-test-user', JSON.stringify(sviUser));
+
+    expect(res.status).toBe(403);
+    expect(prisma.carcasse.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/api-express/src/controllers/carcasse.ts
+++ b/api-express/src/controllers/carcasse.ts
@@ -2,7 +2,7 @@ import express from 'express';
 const router: express.Router = express.Router();
 import passport from 'passport';
 import { catchErrors } from '~/middlewares/errors';
-import type { CarcassesGetResponse } from '~/types/responses';
+import type { CarcassesGetResponse, CarcassesRefuseesResponse } from '~/types/responses';
 import prisma from '~/prisma';
 import {
   EntityRelationStatus,
@@ -33,6 +33,71 @@ const zodQuerySchema = z.object({
   withDeleted: z.string(),
 });
 
+// Périmètre d'accès aux carcasses selon le rôle. Retourne le WHERE Prisma (ou null si rôle non
+// supporté). Partagé entre le pull delta `/carcasse` et la route `/carcasse/refusees/:fei_numero`
+// pour garantir une autorisation strictement identique entre les deux.
+async function getCarcasseAccessWhere(
+  user: RequestWithUser['user']
+): Promise<Prisma.CarcasseWhereInput | null> {
+  const userEntityRelations = await prisma.entityAndUserRelations.findMany({
+    where: {
+      owner_id: user.id,
+      relation: EntityRelationType.CAN_HANDLE_CARCASSES_ON_BEHALF_ENTITY,
+      status: { in: [EntityRelationStatus.ADMIN, EntityRelationStatus.MEMBER] },
+    },
+    select: { entity_id: true },
+  });
+  const userEntityIds = userEntityRelations.map((r) => r.entity_id);
+
+  if (user.roles.includes(UserRoles.SVI)) {
+    return {
+      svi_assigned_at: { not: null },
+      OR: [{ svi_entity_id: { in: userEntityIds } }, { next_owner_entity_id: { in: userEntityIds } }],
+    };
+  }
+  if (user.roles.includes(UserRoles.CHASSEUR)) {
+    return {
+      OR: [
+        { premier_detenteur_user_id: user.id },
+        { examinateur_initial_user_id: user.id },
+        // Désignation du premier détenteur (asso) : on n'expose la fiche aux membres de l'entité
+        // qu'une fois la fiche réellement transmise (sortie de l'examinateur initial).
+        {
+          premier_detenteur_entity_id: { in: userEntityIds },
+          current_owner_role: { not: FeiOwnerRole.EXAMINATEUR_INITIAL },
+        },
+        {
+          next_owner_entity_id: { in: userEntityIds },
+          current_owner_role: { not: FeiOwnerRole.EXAMINATEUR_INITIAL },
+        },
+        { prev_owner_entity_id: { in: userEntityIds } },
+        { current_owner_entity_id: { in: userEntityIds } },
+        { next_owner_user_id: user.id },
+        { prev_owner_user_id: user.id },
+        { current_owner_user_id: user.id },
+      ],
+    };
+  }
+  if (
+    user.roles.includes(UserRoles.ETG) ||
+    user.roles.includes(UserRoles.COLLECTEUR_PRO) ||
+    user.roles.includes(UserRoles.COMMERCE_DE_DETAIL) ||
+    user.roles.includes(UserRoles.CANTINE_OU_RESTAURATION_COLLECTIVE) ||
+    user.roles.includes(UserRoles.ASSOCIATION_CARITATIVE) ||
+    user.roles.includes(UserRoles.REPAS_DE_CHASSE_OU_ASSOCIATIF) ||
+    user.roles.includes(UserRoles.CONSOMMATEUR_FINAL)
+  ) {
+    return {
+      OR: [
+        { CarcasseIntermediaire: { some: { intermediaire_entity_id: { in: userEntityIds } } } },
+        { next_owner_entity_id: { in: userEntityIds } },
+        { current_owner_entity_id: { in: userEntityIds } },
+      ],
+    };
+  }
+  return null;
+}
+
 router.get(
   '/',
   passport.authenticate('user', { session: false }),
@@ -62,96 +127,9 @@ router.get(
     const includeDeleted = withDeleted === 'true';
     const afterDate = Number(after) ? new Date(Number(after)) : undefined;
 
-    // Base query conditions
-    let where: Prisma.CarcasseWhereInput = {};
-
-    // Pre-fetch entity IDs the user works for (used in carcasse-level queries)
-    const userEntityRelations = await prisma.entityAndUserRelations.findMany({
-      where: {
-        owner_id: req.user.id,
-        relation: EntityRelationType.CAN_HANDLE_CARCASSES_ON_BEHALF_ENTITY,
-        status: { in: [EntityRelationStatus.ADMIN, EntityRelationStatus.MEMBER] },
-      },
-      select: { entity_id: true },
-    });
-    const userEntityIds = userEntityRelations.map((r) => r.entity_id);
-
-    if (req.user.roles.includes(UserRoles.SVI)) {
-      where = {
-        svi_assigned_at: { not: null },
-        OR: [
-          {
-            svi_entity_id: { in: userEntityIds },
-          },
-          {
-            next_owner_entity_id: { in: userEntityIds },
-          },
-        ],
-      };
-    } else if (req.user.roles.includes(UserRoles.CHASSEUR)) {
-      where = {
-        OR: [
-          {
-            premier_detenteur_user_id: req.user.id,
-          },
-          {
-            examinateur_initial_user_id: req.user.id,
-          },
-          // Désignation du premier détenteur (asso) : on n'expose la fiche aux membres de
-          // l'entité qu'une fois la fiche réellement transmise (sortie de l'examinateur initial),
-          // pas dès la simple désignation en cours de préparation.
-          {
-            premier_detenteur_entity_id: { in: userEntityIds },
-            current_owner_role: { not: FeiOwnerRole.EXAMINATEUR_INITIAL },
-          },
-          {
-            next_owner_entity_id: { in: userEntityIds },
-            current_owner_role: { not: FeiOwnerRole.EXAMINATEUR_INITIAL },
-          },
-          {
-            prev_owner_entity_id: { in: userEntityIds },
-          },
-          {
-            current_owner_entity_id: { in: userEntityIds },
-          },
-          {
-            next_owner_user_id: req.user.id,
-          },
-          {
-            prev_owner_user_id: req.user.id,
-          },
-          {
-            current_owner_user_id: req.user.id,
-          },
-        ],
-      };
-    } else if (
-      req.user.roles.includes(UserRoles.ETG) ||
-      req.user.roles.includes(UserRoles.COLLECTEUR_PRO) ||
-      req.user.roles.includes(UserRoles.COMMERCE_DE_DETAIL) ||
-      req.user.roles.includes(UserRoles.CANTINE_OU_RESTAURATION_COLLECTIVE) ||
-      req.user.roles.includes(UserRoles.ASSOCIATION_CARITATIVE) ||
-      req.user.roles.includes(UserRoles.REPAS_DE_CHASSE_OU_ASSOCIATIF) ||
-      req.user.roles.includes(UserRoles.CONSOMMATEUR_FINAL)
-    ) {
-      where = {
-        OR: [
-          {
-            CarcasseIntermediaire: {
-              some: {
-                intermediaire_entity_id: { in: userEntityIds },
-              },
-            },
-          },
-          {
-            next_owner_entity_id: { in: userEntityIds },
-          },
-          {
-            current_owner_entity_id: { in: userEntityIds },
-          },
-        ],
-      };
-    } else {
+    // Base query conditions : périmètre d'accès role-aware (partagé avec /refusees/:fei_numero).
+    const accessWhere = await getCarcasseAccessWhere(req.user);
+    if (!accessWhere) {
       capture(`User role not supported: ${req.user.roles.join(', ')}`, { user: req.user });
       res.status(403).send({
         ok: false,
@@ -160,6 +138,7 @@ router.get(
       });
       return;
     }
+    const where: Prisma.CarcasseWhereInput = { ...accessWhere };
 
     if (!includeDeleted) {
       where.deleted_at = null;
@@ -253,6 +232,86 @@ router.get(
         hasMore: carcasses.length === parsedLimit,
         total,
       },
+      error: '',
+    });
+  })
+);
+
+// Carcasses d'une fiche hors du périmètre de synchro delta de l'utilisateur : refusées, manquantes
+// ou orphelines. Une carcasse refusée « sort du circuit » (ses next/current_owner ne suivent plus la
+// transmission de la fiche) et son updated_at ne rebouge pas ensuite : le pull delta /carcasse ne la
+// renvoie donc jamais aux détenteurs suivants ni au SVI, alors qu'elle fait partie de leur champ de
+// contrôle. Cette route les fournit à la demande (à l'ouverture d'une fiche), pour merge dans le store.
+router.get(
+  '/refusees/:fei_numero',
+  passport.authenticate('user', { session: false }),
+  catchErrors(async (req: RequestWithUser, res: express.Response<CarcassesRefuseesResponse>) => {
+    if (!req.user.activated) {
+      res.status(400).send({ ok: false, data: null, error: "Le compte n'est pas activé" });
+      return;
+    }
+    const feiNumero = req.params.fei_numero;
+    if (!feiNumero) {
+      res.status(400).send({ ok: false, data: null, error: 'Le numéro de fiche est obligatoire' });
+      return;
+    }
+
+    const accessWhere = await getCarcasseAccessWhere(req.user);
+    if (!accessWhere) {
+      capture(`User role not supported: ${req.user.roles.join(', ')}`, { user: req.user });
+      res.status(403).send({ ok: false, data: null, error: "Vous n'avez pas les permissions." });
+      return;
+    }
+
+    // Autorisation : l'utilisateur doit avoir accès à au moins une carcasse de la fiche (via son
+    // périmètre normal) pour consulter les carcasses hors périmètre de cette même fiche.
+    const inScopeCount = await prisma.carcasse.count({
+      where: { fei_numero: feiNumero, ...accessWhere },
+    });
+    if (inScopeCount === 0) {
+      res.status(403).send({ ok: false, data: null, error: "Vous n'avez pas accès à cette fiche." });
+      return;
+    }
+
+    // Les carcasses de la fiche hors périmètre normal (refusées/manquantes/orphelines).
+    const carcasses = await prisma.carcasse.findMany({
+      where: { fei_numero: feiNumero, NOT: accessWhere },
+    });
+
+    const carcasseIds = carcasses.map((c) => c.zacharie_carcasse_id);
+    const carcassesIntermediaires = carcasseIds.length
+      ? await prisma.carcasseIntermediaire.findMany({
+          where: { zacharie_carcasse_id: { in: carcasseIds } },
+        })
+      : [];
+
+    // Entités référencées par ces carcasses et leurs intermédiaires (noms des destinataires, motifs
+    // de refus) — nécessaires à l'affichage côté front.
+    const entityIds = new Set<string>();
+    for (const c of carcasses) {
+      if (c.current_owner_entity_id) entityIds.add(c.current_owner_entity_id);
+      if (c.next_owner_entity_id) entityIds.add(c.next_owner_entity_id);
+      if (c.prev_owner_entity_id) entityIds.add(c.prev_owner_entity_id);
+      if (c.svi_entity_id) entityIds.add(c.svi_entity_id);
+      if (c.latest_intermediaire_entity_id) entityIds.add(c.latest_intermediaire_entity_id);
+    }
+    for (const i of carcassesIntermediaires) {
+      if (i.intermediaire_entity_id) entityIds.add(i.intermediaire_entity_id);
+      if (i.intermediaire_depot_entity_id) entityIds.add(i.intermediaire_depot_entity_id);
+    }
+    const entities = (
+      await prisma.entity.findMany({ where: { id: { in: [...entityIds].filter(Boolean) } } })
+    ).map(
+      (entity): EntityWithUserRelation => ({
+        ...entity,
+        relation: EntityRelationType.NONE,
+        relationStatus: undefined,
+      })
+    );
+
+    res.status(200).json({
+      ok: true,
+      data: { carcasses, carcassesIntermediaires, entities },
       error: '',
     });
   })

--- a/api-express/src/types/responses.ts
+++ b/api-express/src/types/responses.ts
@@ -238,6 +238,18 @@ export interface CarcassesGetResponse {
   error: string;
 }
 
+// Carcasses d'une fiche hors du périmètre de synchro delta (refusées/manquantes/orphelines),
+// récupérées à la demande par fiche puis mergées dans le store. Voir GET /carcasse/refusees/:fei_numero.
+export interface CarcassesRefuseesResponse {
+  ok: boolean;
+  data: {
+    carcasses: Array<Carcasse>;
+    carcassesIntermediaires: Array<CarcasseIntermediaire>;
+    entities: Array<EntityWithUserRelation>;
+  } | null;
+  error: string;
+}
+
 export interface SviCarcasseAVenir {
   zacharie_carcasse_id: string;
   fei_numero: string;

--- a/app-local-first-react-router/src/routes/collecteur/collecteur-fei.tsx
+++ b/app-local-first-react-router/src/routes/collecteur/collecteur-fei.tsx
@@ -46,6 +46,7 @@ import NotFound from '@app/components/NotFound';
 import FeiAucuneAction from '@app/components/FeiAucuneAction';
 import Chargement from '@app/components/Chargement';
 import { loadData, useLoaderEffect } from '@app/utils/load-data';
+import { loadCarcassesRefusees } from '@app/utils/load-carcasses-refusees';
 import { CarcasseTransmission } from '@app/types/carcasse';
 import { useGetTransmissionFromURLParams } from '@app/utils/get-transmissions-sorted';
 
@@ -67,7 +68,9 @@ export default function CollecteurFei(props: Props) {
         setHasTriedLoading(true);
         console.error(error);
       });
-  }, []);
+    // Carcasses refusées/manquantes en amont : hors périmètre du pull delta, on les charge par fiche.
+    loadCarcassesRefusees(params.fei_numero!);
+  }, [params.fei_numero]);
 
   if (!fei) {
     return hasTriedLoading ? <NotFound /> : <Chargement />;

--- a/app-local-first-react-router/src/routes/etg/etg-fei.tsx
+++ b/app-local-first-react-router/src/routes/etg/etg-fei.tsx
@@ -47,6 +47,7 @@ import NotFound from '@app/components/NotFound';
 import FeiAucuneAction from '@app/components/FeiAucuneAction';
 import Chargement from '@app/components/Chargement';
 import { loadData, useLoaderEffect } from '@app/utils/load-data';
+import { loadCarcassesRefusees } from '@app/utils/load-carcasses-refusees';
 import { CarcasseTransmission } from '@app/types/carcasse';
 import { useGetTransmissionFromURLParams } from '@app/utils/get-transmissions-sorted';
 
@@ -68,7 +69,9 @@ export default function EtgFei(props: Props) {
         setHasTriedLoading(true);
         console.error(error);
       });
-  }, []);
+    // Carcasses refusées/manquantes en amont : hors périmètre du pull delta, on les charge par fiche.
+    loadCarcassesRefusees(params.fei_numero!);
+  }, [params.fei_numero]);
 
   if (!fei) {
     return hasTriedLoading ? <NotFound /> : <Chargement />;

--- a/app-local-first-react-router/src/routes/svi/svi-fei.tsx
+++ b/app-local-first-react-router/src/routes/svi/svi-fei.tsx
@@ -28,6 +28,7 @@ import Section from '@app/components/Section';
 import CardCarcasse from '@app/components/CardCarcasse';
 import { PendingModificationBanner } from '@app/components/CarcasseModificationRequest';
 import { loadData, useLoaderEffect } from '@app/utils/load-data';
+import { loadCarcassesRefusees } from '@app/utils/load-carcasses-refusees';
 import { useGetTransmissionFromURLParams } from '@app/utils/get-transmissions-sorted';
 import { CarcasseTransmission } from '@app/types/carcasse';
 
@@ -40,7 +41,9 @@ export default function SviFeiLoader() {
   useLoaderEffect(() => {
     window.scrollTo({ top: 0, behavior: 'instant' });
     loadData('svi-fei').then(() => setHasTriedLoading(true));
-  }, []);
+    // Carcasses refusées/manquantes en amont : hors périmètre du pull delta, on les charge par fiche.
+    loadCarcassesRefusees(params.fei_numero!);
+  }, [params.fei_numero]);
 
   if (!fei) {
     return hasTriedLoading ? <NotFound /> : <Chargement />;

--- a/app-local-first-react-router/src/utils/load-carcasses-refusees.ts
+++ b/app-local-first-react-router/src/utils/load-carcasses-refusees.ts
@@ -1,0 +1,55 @@
+import type { CarcassesRefuseesResponse } from '@api/src/types/responses';
+import useZustandStore from '@app/zustand/store';
+import useUser from '@app/zustand/user';
+import API from '@app/services/api';
+import { mergeItems } from './merge-fetched-items';
+import { getFeiAndCarcasseAndIntermediaireIds } from './get-carcasse-intermediaire-id';
+
+// Charge les carcasses d'une fiche hors du périmètre de synchro delta (refusées/manquantes/
+// orphelines) et les merge dans le store. Le pull delta /carcasse ne les renvoie jamais aux
+// détenteurs suivants ni au SVI (leur updated_at ne rebouge pas après le refus), alors qu'elles
+// font partie du champ de contrôle : on va donc les chercher par fiche, à la demande.
+//
+// On ne touche PAS lastUpdateFromServer : ce chargement est hors du curseur delta.
+export async function loadCarcassesRefusees(feiNumero: string) {
+  if (!feiNumero) return;
+  if (!useZustandStore.getState().isOnline) return;
+
+  const res = (await API.get({ path: `/carcasse/refusees/${feiNumero}` }).then((r) => r)) as
+    | CarcassesRefuseesResponse
+    | undefined;
+  if (!res?.ok || !res.data) return;
+  // Garde contre une déconnexion pendant le fetch : ne pas réécrire un store fraîchement reset.
+  if (!useUser.getState().user) return;
+
+  const { carcasses, carcassesIntermediaires, entities } = res.data;
+  if (!carcasses.length) return;
+
+  const newCarcasses = mergeItems({
+    oldItems: Object.values(useZustandStore.getState().carcasses) || [],
+    newItems: carcasses,
+    idKey: (c) => c.zacharie_carcasse_id,
+  });
+
+  const newCarcassesIntermediaires = mergeItems({
+    oldItems: Object.values(useZustandStore.getState().carcassesIntermediaireById) || [],
+    newItems: carcassesIntermediaires,
+    idKey: getFeiAndCarcasseAndIntermediaireIds,
+  });
+
+  // Comme load-carcasses : on ne comble que les trous, pour préserver la relation metadata des
+  // entités déjà chargées (via load-my-relations) — les entités de fiche portent la relation NONE.
+  const newEntities = { ...useZustandStore.getState().entities };
+  for (const entity of entities) {
+    if (!entity.deleted_at && !newEntities[entity.id]) {
+      newEntities[entity.id] = entity;
+    }
+  }
+
+  useZustandStore.setState(() => ({
+    carcasses: newCarcasses,
+    carcassesRegistry: Object.values(newCarcasses),
+    carcassesIntermediaireById: newCarcassesIntermediaires,
+    entities: newEntities,
+  }));
+}

--- a/app-local-first-react-router/src/utils/useCarcasseStatusAndRefus.tsx
+++ b/app-local-first-react-router/src/utils/useCarcasseStatusAndRefus.tsx
@@ -38,7 +38,7 @@ export function useCarcasseStatusAndRefus(carcasse: Carcasse) {
           carcasse.intermediaire_carcasse_refus_intermediaire_id!
         );
         const carcasseIntermediaire = carcassesIntermediaires[id];
-        const entity = entities[carcasseIntermediaire.intermediaire_entity_id!];
+        const entity = entities[carcasseIntermediaire?.intermediaire_entity_id!];
         const manquant = carcasse.type === CarcasseType.PETIT_GIBIER ? 'Manquant' : 'Manquante';
         return `${manquant} au moment de la collecte par ${entity?.nom_d_usage}`;
       }
@@ -50,9 +50,9 @@ export function useCarcasseStatusAndRefus(carcasse: Carcasse) {
           carcasse.intermediaire_carcasse_refus_intermediaire_id!
         );
         const carcasseIntermediaire = carcassesIntermediaires[id];
-        const entity = entities[carcasseIntermediaire.intermediaire_entity_id!];
+        const entity = entities[carcasseIntermediaire?.intermediaire_entity_id!];
         const refusé = carcasse.type === CarcasseType.PETIT_GIBIER ? 'Refusé' : 'Refusée';
-        let refus = `${refusé} par ${entity.nom_d_usage}`;
+        let refus = `${refusé} par ${entity?.nom_d_usage}`;
         if (carcasse.intermediaire_carcasse_refus_motif) {
           refus += `\u00A0: ${carcasse.intermediaire_carcasse_refus_motif}`;
         }
@@ -81,7 +81,7 @@ export function useCarcasseStatusAndRefus(carcasse: Carcasse) {
           carcasse.intermediaire_carcasse_refus_intermediaire_id!
         );
         const carcasseIntermediaire = carcassesIntermediaires[id];
-        const entity = entities[carcasseIntermediaire.intermediaire_entity_id!];
+        const entity = entities[carcasseIntermediaire?.intermediaire_entity_id!];
         return `manquant pour ${entity?.nom_d_usage}`;
       }
       case CarcasseStatus.MANQUANTE_SVI:
@@ -92,8 +92,8 @@ export function useCarcasseStatusAndRefus(carcasse: Carcasse) {
           carcasse.intermediaire_carcasse_refus_intermediaire_id!
         );
         const carcasseIntermediaire = carcassesIntermediaires[id];
-        const entity = entities[carcasseIntermediaire.intermediaire_entity_id!];
-        return `refusé par ${entity.nom_d_usage}`;
+        const entity = entities[carcasseIntermediaire?.intermediaire_entity_id!];
+        return `refusé par ${entity?.nom_d_usage}`;
       }
       case CarcasseStatus.SAISIE_TOTALE:
       case CarcasseStatus.SAISIE_PARTIELLE: {


### PR DESCRIPTION
Une carcasse refusée « sort du circuit » : ses next/current_owner ne suivent plus la transmission de la fiche et son updated_at ne rebouge pas ensuite. Le pull delta /carcasse (chargement par carcasse depuis #392) ne la renvoyait donc jamais aux détenteurs suivants ni au SVI, faisant disparaître le bloc « carcasses déjà refusées » alors qu'elles font partie de leur champ de contrôle.

Nouvelle route GET /carcasse/refusees/:fei_numero qui fournit à la demande les carcasses d'une fiche hors du périmètre delta (refusées/manquantes/orphelines)
+ leurs CarcasseIntermediaire + entités. Autorisation role-aware partagée avec le pull via getCarcasseAccessWhere. Le front les charge à l'ouverture d'une fiche (ETG/collecteur/SVI) et les merge dans le store, sans toucher lastUpdateFromServer.